### PR TITLE
Bump WP and WC compatibility

### DIFF
--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -7,8 +7,8 @@
  * Author URI: http://woocommerce.com/
  * Version: 1.4.14
  * Requires at least: 4.4
- * Tested up to: 5.3
- * WC tested up to: 3.8
+ * Tested up to: 5.4
+ * WC tested up to: 4.0
  * WC requires at least: 2.6
  *
  */

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 4.4
-Tested up to: 5.3
+Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: 1.4.14
 License: GPLv3
@@ -38,7 +38,11 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 1.4.14 - 2019-10-24
+= 1.4.15 - 2020-xx-xx =
+ * Tweak - WC tested up to 4.0
+ * Tweak - WP tested up to 5.4
+
+= 1.4.14 - 2019-10-24 =
  * Fix   - Incorrect API response handling for subscription renewal payments.
  * Tweak - WC tested up to 3.8
  * Tweak - WP tested up to 5.3


### PR DESCRIPTION
Fixes #15 

To test:
- install the plugin on a site running WooCommerce 4.0.x and WordPress 5.4.x
- ensure you can complete a sandboxed checkout
- ensure the order shows ITN success in the order notes

Note: We will be running the woorelease script to take care of updating all the versions to 1.4.15 and releasing after this is merged.