### PR TITLE
Sign request to PayFast

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** PayFast Changelog ***
 
+= 1.4.16 - 2020-05-20 =
+ * Fix - Actually generate the signature and pass it through to PayFast.
+ * Tweak - WC tested up to 4.1
+ * Tweak - WP tested up to 5.4
+
 = 1.4.15 - 2020-03-30 =
  * Tweak - WC tested up to 4.0
  * Tweak - WP tested up to 5.4

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -243,7 +243,6 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			'custom_str1'      => self::get_order_prop( $order, 'order_key' ),
 			'custom_str2'      => 'WooCommerce/' . WC_VERSION . '; ' . get_site_url(),
 			'custom_str3'      => self::get_order_prop( $order, 'id' ),
-			'source'           => 'WooCommerce-Free-Plugin',
 		);
 
 		// add subscription parameters
@@ -273,9 +272,12 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		}
 
 		$payfast_args_array = array();
+        $sign_strings = [];
 		foreach ( $this->data_to_send as $key => $value ) {
+            $sign_strings[] = esc_attr( $key ) . '=' . urlencode(str_replace('&amp;', '&', trim( $value )));
 			$payfast_args_array[] = '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $value ) . '" />';
 		}
+        $payfast_args_array[] = '<input type="hidden" name="signature" value="' . md5(implode('&', $sign_strings) . '&passphrase=' . urlencode($this->pass_phrase)) . '" />';
 
 		return '<form action="' . esc_url( $this->url ) . '" method="post" id="payfast_payment_form">
 				' . implode( '', $payfast_args_array ) . '


### PR DESCRIPTION
This plugin for WordPress was not signing requests to PayFast.  This pull request fixes this issue by adding a signature to the form to send to PayFast for the to compare the signature sent with the one they generate on their side.

I also had to remove the source field to get the signature validation to pass.