### PR TITLE
Add CloudFlare "HTTP_CF_CONNECTING_IP" support

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1228,6 +1228,12 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 			$source_ip = (string) rest_is_ip_address( trim( current( preg_split( '/[,:]/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) ) ?: $source_ip;
 		}
+		
+		// Adds support for CloudFlare "HTTP_CF_CONNECTING_IP"
+        	// https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-
+        	if ( isset($_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+            		$source_ip = (string) rest_is_ip_address( trim( current( sanitize_text_field( wp_unslash( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) ) ) ) ?: $source_ip;
+        	}
 
 		$this->log( "Valid IPs:\n" . print_r( $valid_ips, true ) );
 		$is_valid_ip = in_array( $source_ip, $valid_ips );


### PR DESCRIPTION
Refer to issues: 
https://github.com/woocommerce/woocommerce-gateway-payfast/issues/7
https://github.com/woocommerce/woocommerce-gateway-payfast/issues/11

Change addresses:
The error "PF_ERR_BAD_SOURCE_IP" occurs when using CloudFlare's reverse proxy due to the source address rewrite.

As per "https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-", CloudFlare includes a field ("HTTP_CF_CONNECTING_IP") in the response header to identify the originating IP.


Comments:
The addition has not been tested/validated, this should fix the indicated issues but requires testing.