### PR TITLE
Fix Object could not be converted to string

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** PayFast Changelog ***
 
+= 1.4.16 - 2020-xx-xx =
+ * Fix - Fix Object could not be converted to string when renewing a subscription.
+
 = 1.4.15 - 2020-03-30 =
  * Tweak - WC tested up to 4.0
  * Tweak - WP tested up to 5.4

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -995,7 +995,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 		// Check adhoc bank charge response
 		if ( $command == 'adhoc' && 'true' !== json_decode( $results['body'])->data->response ) {
-			$this->log( "Error posting API request:\n" . print_r( json_decode( $results['body'] )->data->response , true ) );
+			$this->log( "Error posting API request:\n" . print_r( json_decode( $results['body'] )->data , true ) );
 			return new WP_Error( json_decode( $results['body'] )->data->message, json_decode( $results['body'] )->data->response, $results );
 		}
 

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -994,9 +994,14 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		}
 
 		// Check adhoc bank charge response
-		if ( $command == 'adhoc' && 'true' !== json_decode( $results['body'])->data->response ) {
-			$this->log( "Error posting API request:\n" . print_r( json_decode( $results['body'] )->data , true ) );
-			return new WP_Error( json_decode( $results['body'] )->data->message, json_decode( $results['body'] )->data->response, $results );
+		$results_data = json_decode( $results['body'], true )['data'];
+		if ( $command == 'adhoc' && 'true' !== $results_data['response'] ) {
+			$this->log( "Error posting API request:\n" . print_r( $results_data , true ) );
+
+			$code         = is_array( $results_data['response'] ) ? $results_data['response']['code'] : $results_data['response'];
+			$message      = is_array( $results_data['response'] ) ? $results_data['response']['reason'] : $results_data['message'];
+			// Use trim here to display it properly e.g. on an order note, since PayFast can include CRLF in a message.
+			return new WP_Error( $code, trim( $message ), $results );
 		}
 
 		$maybe_json = json_decode( $results['body'], true );

--- a/readme.txt
+++ b/readme.txt
@@ -38,14 +38,12 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 1.4.16 - 2020-xx-xx =
+ * Fix - Fix Object could not be converted to string when renewing a subscription.
+
 = 1.4.15 - 2020-03-30 =
  * Tweak - WC tested up to 4.0
  * Tweak - WP tested up to 5.4
-
-= 1.4.14 - 2019-10-24 =
- * Fix   - Incorrect API response handling for subscription renewal payments.
- * Tweak - WC tested up to 3.8
- * Tweak - WP tested up to 5.3
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-payfast/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #20 

When a subscription can't be renewed because of some card or funds issue, the response property of the API result is an array, instead of a string. This causes issues when it's used in a sprintf to add the order note.

This is a response for a card declined error (h/t @bluekable):
![image](https://user-images.githubusercontent.com/7714042/99703106-78228300-2a75-11eb-8d22-8c47b75013bb.png)

And this is the one for a canceled subscription:
![image](https://user-images.githubusercontent.com/7714042/99703311-b9b32e00-2a75-11eb-955e-d42882c7ce51.png)

### Proposed changes

- Improve logs for adhoc errors 
- Fix object can't be converted to string on subscription renewal

### Testing instructions

1. **The response property is a string**
1.1. Create a new subscription
1.2. Using the [sandbox management interface](https://sandbox.payfast.co.za/), cancel the new subscription
1.3. Try to renew the subscription from WooCommerce
1.4. Assert that the renewal fails and that the order note has the appropriate message
    <img src="https://user-images.githubusercontent.com/7714042/99703785-4d84fa00-2a76-11eb-92ec-d4e4a4e70b42.png" height="200px" />
2. **The response property is an array**
2.1. Create a new subscription
2.2. Simulate a declined card or manually set `$results_data` and renew the subscription
    ```
    $results_data = [
        'response' => [
            'code'   => '57',
            'reason' => 'Your card was declined for payment. Please contact your bank for mode information. (57)'
         ],
        'message' => 'Failure'
    ];
    ```
    2.3. Assert that the renewal fails and that the order note has the appropriate message
    <img src="https://user-images.githubusercontent.com/7714042/99704305-f3d0ff80-2a76-11eb-8c13-5cbacdb0b7c9.png" height="200px" />

