### PR TITLE
PHP 8.0 compatibility and version bumps

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,10 @@
 *** PayFast Changelog ***
 
 = 1.4.16 - 2020-xx-xx =
- * Fix - Fix Object could not be converted to string when renewing a subscription.
+ * Fix   - Fix Object could not be converted to string when renewing a subscription.
+ * Tweak - WC tested up to 4.7
+ * Tweak - WP tested up to 5.6
+ * Tweak - PHP 8.0 compatibility.
 
 = 1.4.15 - 2020-03-30 =
  * Tweak - WC tested up to 4.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** PayFast Changelog ***
 
-= 1.4.16 - 2020-xx-xx =
+= 1.4.17 - 2020-xx-xx =
  * Fix   - Fix Object could not be converted to string when renewing a subscription.
  * Tweak - WC tested up to 4.7
  * Tweak - WP tested up to 5.6

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -7,8 +7,8 @@
  * Author URI: http://woocommerce.com/
  * Version: 1.4.16
  * Requires at least: 4.4
- * Tested up to: 5.4
- * WC tested up to: 4.0
+ * Tested up to: 5.6
+ * WC tested up to: 4.7
  * WC requires at least: 2.6
  *
  */

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 1.4.16 - 2020-xx-xx =
+= 1.4.17 - 2020-xx-xx =
  * Fix   - Fix Object could not be converted to string when renewing a subscription.
  * Tweak - WC tested up to 4.7
  * Tweak - WP tested up to 5.6

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,10 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 1.4.16 - 2020-xx-xx =
- * Fix - Fix Object could not be converted to string when renewing a subscription.
+ * Fix   - Fix Object could not be converted to string when renewing a subscription.
+ * Tweak - WC tested up to 4.7
+ * Tweak - WP tested up to 5.6
+ * Tweak - PHP 8.0 compatibility.
 
 = 1.4.15 - 2020-03-30 =
  * Tweak - WC tested up to 4.0


### PR DESCRIPTION
Closes #27 

Preps the release of 1.4.17 and bumps the tested versions to WC 4.7 and WP 5.6.