### PR TITLE
Add signature to the request to PayFast

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -273,9 +273,19 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		}
 
 		$payfast_args_array = array();
+        $sign_strings = [];
 		foreach ( $this->data_to_send as $key => $value ) {
+		    if ($key !== 'source') {
+                $sign_strings[] = esc_attr( $key ) . '=' . urlencode(str_replace('&amp;', '&', trim( $value )));
+            }
 			$payfast_args_array[] = '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $value ) . '" />';
 		}
+
+		if (!empty($this->pass_phrase)) {
+            $payfast_args_array[] = '<input type="hidden" name="signature" value="' . md5(implode('&', $sign_strings) . '&passphrase=' . urlencode($this->pass_phrase)) . '" />';
+        } else {
+            $payfast_args_array[] = '<input type="hidden" name="signature" value="' . md5(implode('&', $sign_strings)) . '" />';
+        }
 
 		return '<form action="' . esc_url( $this->url ) . '" method="post" id="payfast_payment_form">
 				' . implode( '', $payfast_args_array ) . '


### PR DESCRIPTION
These changes will add a signature to the initial request and will not affect existing stores that don't have a passphrase set in the plugin, as long is it matches their PayFast account.

If there is a passphrase set on their PayFast account, the passphrase set in the plugin is required.