### PR TITLE
Add org labels sync

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,5 +1,8 @@
 name: Sync Woo Labels to Repository
-on: [issues, pull_request]
+on:
+  schedule:
+    # run at noon every monday
+    - cron:  '0 12 * * 1'
 jobs:
   sync-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,11 @@
+name: Sync Woo Labels to Repository
+on: [issues, pull_request]
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    name: Sync repository labels
+    steps:
+      - uses: woocommerce/woo-std-labels@v1
+        with:
+          labels-path: /home/runner/work/_actions/woocommerce/woo-std-labels/v1/labels.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #36 

Adds an action that synchronizes woo-wide GitHub labels.