### PR TITLE
Don't access order id directly

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1362,7 +1362,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	public function display_order_fee( $order_id ) {
 
 		$order = wc_get_order( $order_id );
-		$fee = get_post_meta( $order->ID, 'payfast_amount_fee', TRUE);
+		$fee = get_post_meta( self::get_order_prop( $order, 'id' ), 'payfast_amount_fee', TRUE);
 
 		if (! $fee ) {
 			return;
@@ -1391,7 +1391,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	public function display_order_net( $order_id ) {
 
 		$order = wc_get_order( $order_id );
-		$net = get_post_meta( $order->ID, 'payfast_amount_net', TRUE);
+		$net = get_post_meta( self::get_order_prop( $order, 'id' ), 'payfast_amount_net', TRUE);
 
 		if (! $net ) {
 			return;


### PR DESCRIPTION
This PR removes a direct access to `$order->id` that was making an error to appear in the admin.

## Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/111159848-cf56e100-8599-11eb-870f-315ac5a35e8d.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/111159881-d978df80-8599-11eb-9770-7886d9734140.png)

## Testing instructions

* Set up PayFast payment gateway using the [sandbox mode](https://support.payfast.co.za/portal/en/kb/articles/how-do-i-test-woocommerce-in-sandbox-mode).
* Make a purchase and pay with PayFast.
* In the admin, open the order that has been placed.
* Verify there isn't a PHP error stack (see screenshots above).