### PR TITLE
Add methods required for WooCommerce onboarding setup

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -9,6 +9,7 @@
  * @category Payment Gateways
  * @author WooCommerce
  */
+
 class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 	/**
@@ -173,11 +174,11 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	 *
 	 * @return array
 	 */
-	public function get_setup_form_field_keys() {
+	public function get_required_settings_keys() {
 		return array(
 			'merchant_id',
 			'merchant_key',
-			'pass_phrase',
+			'pass_phrase'
 		);
 	}
 

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -189,7 +189,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	 * @return bool
 	 */
 	public function needs_setup() {
-		return ! $this->merchant_id || ! $this->merchant_key || ! $this->pass_phrase;
+		return ! $this->get_option( 'merchant_id' ) || ! $this->get_option( 'merchant_key' ) || ! $this->get_option( 'pass_phrase' );
 	}
 
 	/**

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -169,6 +169,19 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Get the required form field keys for setup.
+	 *
+	 * @return array
+	 */
+	public function get_setup_form_field_keys() {
+		return array(
+			'merchant_id',
+			'merchant_key',
+			'pass_phrase',
+		);
+	}
+
+	/**
 	 * add_testmode_admin_settings_notice()
 	 * Add a notice to the merchant_key and merchant_id fields when in test mode.
 	 *

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -10,6 +10,7 @@
  * @author WooCommerce
  */
 
+
 class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 	/**
@@ -180,6 +181,15 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			'merchant_key',
 			'pass_phrase'
 		);
+	}
+
+	/**
+	 * Determine if the gateway still requires setup.
+	 *
+	 * @return bool
+	 */
+	public function needs_setup() {
+		return ! $this->merchant_id || ! $this->merchant_key || ! $this->pass_phrase;
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the methods needed to allow setup of Payfast during onboarding.

Part of the remote payment gateways project ( https://github.com/woocommerce/woocommerce-admin/issues/6876 ).

### Screenshots

<img width="716" alt="Screen Shot 2021-05-27 at 11 11 35 AM" src="https://user-images.githubusercontent.com/10561050/119851472-69ad9c00-bedc-11eb-99c1-2b226cc53392.png">


### Testing

1. Install and activate this plugin in your `plugins/` directory matching the wp.org slug.  `woocommerce-payfast-gateway`
2. Install and activate the development version of [WooCommerce Admin](https://github.com/woocommerce/woocommerce-admin) ( `git clone https://github.com/woocommerce/woocommerce-admin.git && cd woocommerce-admin && composer install && npm i && npm run build` ).
3. Make sure South Africa is selected as the store country under WooCommerce general settings.
2. Navigate to the Payfast gateway in the payments task `/wp-admin/admin.php?page=wc-admin&task=payments`
3. Fill out the required setting fields.
4. Make sure that the Payfast gateway is moved to the "Enabled payment gateways" section.
5. Make sure that settings are persisted on page refresh.