### PR TITLE
fix/32: Added support for customer payment method change.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1085,6 +1085,11 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			'version'     => 'v1',
 		);
 
+		// Set content length to fix "411: requests require a Content-length header" error.
+		if ( 'cancel' === $command && ! isset( $api_args['body'] ) ) {
+			$api_args['headers']['content-length'] = 0;
+		}
+
 		// generate signature
 		$all_api_variables                = array_merge( $api_args['headers'], (array) $api_args['body'] );
 		$api_args['headers']['signature'] = md5( $this->_generate_parameter_string( $all_api_variables ) );

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -49,7 +49,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			'subscription_amount_changes',
 			'subscription_date_changes',
 			'subscription_payment_method_change', // Subs 1.x support
-			//'subscription_payment_method_change_customer', // see issue #39
+			'subscription_payment_method_change_customer', // Enabled for https://github.com/woocommerce/woocommerce-gateway-payfast/issues/32.
 		);
 
 		$this->init_form_fields();
@@ -89,9 +89,12 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		add_action( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->id, array( $this, 'process_pre_order_payments' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 
-		//Add fees to order
+		// Add fees to order.
 		add_action( 'woocommerce_admin_order_totals_after_total', array( $this, 'display_order_fee') );
 		add_action( 'woocommerce_admin_order_totals_after_total', array( $this, 'display_order_net'), 20 );
+
+		// Change Payment Method actions.
+		add_action( 'woocommerce_subscription_payment_method_updated_from_' . $this->id, array( $this, 'maybe_cancel_subscription_token' ), 10, 2 );
 	}
 
 	/**
@@ -270,6 +273,15 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			'source'           => 'WooCommerce-Free-Plugin',
 		);
 
+		/**
+		 * Check If changing payment method.
+		 * We have to generate Tokenization (ad-hoc) token to charge payments.
+		 */
+		if ( $this->is_subscription( $order_id ) ) {
+			// 2 == ad-hoc subscription type see PayFast API docs
+			$this->data_to_send['subscription_type'] = '2';
+		}
+
 		// add subscription parameters
 		if ( $this->order_contains_subscription( $order_id ) ) {
 			// 2 == ad-hoc subscription type see PayFast API docs
@@ -278,10 +290,11 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 		if ( function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order ) ) {
 			$subscriptions = wcs_get_subscriptions_for_renewal_order( $order_id );
-			// For renewal orders that have subscriptions with renewal flag,
+			$current       = reset( $subscriptions );
+			// For renewal orders that have subscriptions with renewal flag OR renew orders which are paid using payfast.
 			// we will create a new subscription in PayFast and link it to the existing ones in WC.
 			// The old subscriptions in PayFast will be cancelled once we handle the itn request.
-			if ( count ( $subscriptions ) > 0 && $this->_has_renewal_flag( reset( $subscriptions ) ) ) {
+			if ( count( $subscriptions ) > 0 && ( $this->_has_renewal_flag( $current ) || $this->id !== $current->get_payment_method() ) ) {
 				// 2 == ad-hoc subscription type see PayFast API docs
 				$this->data_to_send['subscription_type'] = '2';
 			}
@@ -457,7 +470,8 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			// Check order amount
 			if ( ! $this->amounts_equal( $data['amount_gross'], self::get_order_prop( $order, 'order_total' ) )
 				 && ! $this->order_contains_pre_order( $order_id )
-				 && ! $this->order_contains_subscription( $order_id ) ) {
+				 && ! $this->order_contains_subscription( $order_id )
+				 && ! $this->is_subscription( $order_id ) ) { // if changing payment method.
 				$payfast_error  = true;
 				$payfast_error_message = PF_ERR_AMOUNT_MISMATCH;
 			} elseif ( strcasecmp( $data['custom_str1'], self::get_order_prop( $order, 'order_key' ) ) != 0 ) {
@@ -549,6 +563,31 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			}
 
 			$status = strtolower( $data['payment_status'] );
+
+			/**
+			 * Handle Changing Payment Method.
+			 *   - Save payfast subscription token to handle future payment
+			 *   - (for Payfast to Payfast payment method change) Cancel old token, as future payment will be handle with new token
+			 */
+			if ( $this->is_subscription( $order_id ) && floatval( 0 ) === floatval( $data['amount_gross'] ) ) {
+				$this->log( '- Change Payment Method' );
+				if ( 'complete' === $status && isset( $data['token'] ) ) {
+					$token        = sanitize_text_field( $data['token'] );
+					$subscription = wcs_get_subscription( $order_id );
+					if ( ! empty( $subscription ) && ! empty( $token ) ) {
+						$old_token = $this->_get_subscription_token( $subscription );
+						// Cancel old subscription token of subscription if we have it.
+						if ( ! empty( $old_token ) ) {
+							$this->cancel_subscription_listener( $subscription );
+						}
+
+						// Set new subscription token on subscription.
+						$this->_set_subscription_token( $token, $subscription );
+						$this->log( 'Payfast token updated on Subcription: ' . $order_id );
+					}
+				}
+				return;
+			}
 
 			$subscriptions = array();
 			if ( function_exists( 'wcs_get_subscriptions_for_renewal_order' ) && function_exists( 'wcs_get_subscriptions_for_order' ) ) {
@@ -879,6 +918,36 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	 */
 	protected function _get_pre_order_token( $order ) {
 		return get_post_meta( self::get_order_prop( $order, 'id' ), '_payfast_pre_order_token', true );
+	}
+
+	/**
+	 * Wrapper for WooCommerce subscription function wc_is_subscription.
+	 *
+	 * @param WC_Order $order The order.
+	 * @return bool
+	 */
+	public function is_subscription( $order ) {
+		if ( ! function_exists( 'wcs_is_subscription' ) ) {
+			return false;
+		}
+		return wcs_is_subscription( $order );
+	}
+
+	/**
+	 * Cancel Payfast Tokenization(ad-hoc) token if subscription changed to other payment method.
+	 *
+	 * @param WC_Subscription $subscription       The subscription for which the payment method changed.
+	 * @param string          $new_payment_method New payment method name.
+	 */
+	public function maybe_cancel_subscription_token( $subscription, $new_payment_method ) {
+		$token = $this->_get_subscription_token( $subscription );
+		if ( empty( $token ) || $this->id === $new_payment_method ) {
+			return;
+		}
+		$this->cancel_subscription_listener( $subscription );
+		$this->_delete_subscription_token( $subscription );
+
+		$this->log( 'Payfast subscription token Cancelled.' );
 	}
 
 	/**

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1105,7 +1105,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 		// Check adhoc bank charge response
 		$results_data = json_decode( $results['body'], true )['data'];
-		if ( $command == 'adhoc' && 'true' !== $results_data['response'] ) {
+		if ( $command == 'adhoc' && true !== $results_data['response'] ) {
 			$this->log( "Error posting API request:\n" . print_r( $results_data , true ) );
 
 			$code         = is_array( $results_data['response'] ) ? $results_data['response']['code'] : $results_data['response'];

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -275,7 +275,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 		/**
 		 * Check If changing payment method.
-		 * We have to generate Tokenization (ad-hoc) token to charge payments.
+		 * We have to generate Tokenization (ad-hoc) token to charge future payments.
 		 */
 		if ( $this->is_subscription( $order_id ) ) {
 			// 2 == ad-hoc subscription type see PayFast API docs
@@ -291,7 +291,8 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		if ( function_exists( 'wcs_order_contains_renewal' ) && wcs_order_contains_renewal( $order ) ) {
 			$subscriptions = wcs_get_subscriptions_for_renewal_order( $order_id );
 			$current       = reset( $subscriptions );
-			// For renewal orders that have subscriptions with renewal flag OR renew orders which are paid using payfast.
+			// For renewal orders that have subscriptions with renewal flag OR
+			// For renew orders which are failed to pay by other payment gateway buy now payinh using Payfast.
 			// we will create a new subscription in PayFast and link it to the existing ones in WC.
 			// The old subscriptions in PayFast will be cancelled once we handle the itn request.
 			if ( count( $subscriptions ) > 0 && ( $this->_has_renewal_flag( $current ) || $this->id !== $current->get_payment_method() ) ) {


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #32 

**Ticket**:

**Slack Thread**:

---

### Description

Currently, when the auto-renewal payment gets failed due to any reason (eg: expired cards), there is no way to pay it manually from the front-end side. Also, in the case of expired cards "Retry renewal Payment" is not working. So, customers have to cancel the subscription and re-subscribe.

This PR adds support of `subscription_payment_method_change_customer`, which will enable users to pay failed orders manually and change the payment method of subscription.


### Steps to Test
**Testing Setup Instructions**
- Install and Activate `WooCommerce`, `WooCommerce Subscriptions`, `WooCommerce PayFast Gateway` and Any other payment gateway plugin (eg: Stripe)
- Set store currency to "**South African rand (R)**"
- Setup PayFast Gateway (Sandbox env). You can get credentials from https://sandbox.payfast.co.za/
-  Add Subscription product

**Notes:**
- Plugin Uses Payfast ITNs(webhook) to mark payment complete. So, the test website should be accessible from the internet. (for local env you can use **ngrok**)
- For "**Change Payment Method**", while doing 0.00 payment, Payfast is giving an error on sandbox env. please wait for a few seconds. It will auto success and redirect to the success page. 

**Test cases:**
* * *
<details><summary>Test Case 1 - Payment of the Failed Order</summary>
<p>

- [ ] 1. Add any Subscription product to the cart, Go to Checkout, and complete payment with `PayFast` Payment Gateway
- [ ] 2. Update `Merchant ID` to invalid value and "Process Renewal" from the admin panel. It will generate Failed order on subscription and put subscription on `On Hold`
- [ ] 3. Go to `My Account` > `Subscriptions` on Front-end.
- [ ] 4. Select `On Hold` Subscription, Go to Failed Order and Click on Pay
- [ ] 5. On the Checkout page verify `Payfast` shows in the list of payment gateways to paid with.
- [ ] 6. Complete payment with `Payfast`.
- [ ] 7. Make sure subscription is now `Active`.
- [ ] 8. Make sure future payments will be collect successfully. (By Process renewal from Admin Panel)
- [ ] Test all these steps(3-8) for subscriptions that have failed order with other payment gateways (eg: Stripe). 

</p>
</details>

* * *
<details><summary>Test Case 2 - Change Payment Method (Other Payment Gateway to Payfast)</summary>
<p>

- [ ] Go to My `Account` > `Subscriptions` on your website
- [ ] Select  any `Active` Subscription which have Payment Method other than **Payfast**. (for eg: Stripe)
- [ ] Click on `Change Payment` button
- [ ] Select `PayFast` Payment Gateway and Click on `Change Payment Method` button
- [ ] Complete Payment Process.
- [ ] Make sure subscription is Active.

Follow the below steps to Make sure future payments will be collected successfully.

- [ ] Go to `WooCommerce` > `Subscriptions` in **WP-ADMIN** and select Subscription we just changed payment method.
- [ ] In `Subscription Actions` Meta Box, Choose `Process Renewal` and submit
- [ ] Make sure renewal payment collected successfully and subscription is still `Active`.

</p>
</details>


* * *
<details><summary>Test Case 3 - Change Payment Method (Payfast to Other Payment Gateway)</summary>
<p>

- [ ] 1. Add any Subscription product to the cart, Go to Checkout, and complete payment with `PayFast` Payment Gateway
- [ ] 2. Note the order Id. (this will be useful in later steps)
- [ ] 3. Go to My `Account` > `Subscriptions` on your website
- [ ] 4. Select Subscription (which we signed up at step 1)
- [ ] 5. Click on the `Change Payment` button.
- [ ] 6. Select any other payment gateway (for eg: `Stripe`) and Click `Change Payment Method`
- [ ] 7. Complete Payment Process and Make sure subscription is Active.
- [ ] 8. Make Sure Payfast subscription token is canceled. You can check it from https://sandbox.payfast.co.za/tokenization by Order ID(Payment ID on a page). (moving to another payment should cancel the subscription with payfast gateway.)

</p>
</details>

* * *
<details><summary>Test Case 4 - Change Payment Method (Payfast to Payfast)</summary>
<p>

- [ ] Add any Subscription product to cart, Go to Checkout, and complete payment with `PayFast` Payment Gateway
- [ ] Go to My `Account` > `Subscriptions` on your website
- [ ] Select Subscription and Click on `Change Payment` button
- [ ] Select `PayFast` Payment Gateway and Click on `Change Payment Method` button
- [ ] Complete Payment Process.
- [ ] Make sure subscription is Active.
- [ ] Make Sure Old Payfast subscription token is cancelled. (can be checked from https://sandbox.payfast.co.za/tokenization. more info in Test case 3)

Follow the below steps to Make sure future payments will be collect successfully.

- [ ] Go to `WooCommerce` > `Subscriptions` in **WP-ADMIN** and select Subscription we just changed payment method.
- [ ] In `Subscription Actions` Meta Box, Choose `Process Renewal` and submit
- [ ] Make sure renewal payment collected successfully and subscription is still `Active`.

</p>
</details>

* * *

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
Need to update documentation about added support for `subscription_payment_method_change_customer`

### Changelog Entry

> Added support for customer payment method change.

Closes #32.
Closes #73 
