### PR TITLE
enhancement/62: Added filter on payment data to send.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -296,7 +296,16 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			$this->data_to_send['subscription_type'] = '2';
 		}
 
-		// Allow other plugins to extend this.
+		/**
+		 * Filters Payment data which will be sent to the Payfast.
+		 *
+		 * Allow other plugins to extend Payfast payment data to send.
+		 *
+		 * @since 1.4.21
+		 *
+		 * @param array $this->data_to_send Payment data
+		 * @param int   $order_id           Order id
+		 */
 		$this->data_to_send = apply_filters( 'woocommerce_gateway_payfast_payment_data_to_send', $this->data_to_send, $order_id );
 
 		$payfast_args_array = array();

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -297,9 +297,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		}
 
 		/**
-		 * Filters Payment data which will be sent to the Payfast.
-		 *
-		 * Allow other plugins to extend Payfast payment data to send.
+		 * Allow others to modify payment data before that is sent to Payfast.
 		 *
 		 * @since 1.4.21
 		 *

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -296,6 +296,9 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			$this->data_to_send['subscription_type'] = '2';
 		}
 
+		// Allow other plugins to extend this.
+		$this->data_to_send = apply_filters( 'woocommerce_gateway_payfast_payment_data_to_send', $this->data_to_send, $order_id );
+
 		$payfast_args_array = array();
 		$sign_strings = [];
 		foreach ( $this->data_to_send as $key => $value ) {

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -303,8 +303,8 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		 *
 		 * @since 1.4.21
 		 *
-		 * @param array $this->data_to_send Payment data
-		 * @param int   $order_id           Order id
+		 * @param array $this->data_to_send Payment data.
+		 * @param int   $order_id           Order id.
 		 */
 		$this->data_to_send = apply_filters( 'woocommerce_gateway_payfast_payment_data_to_send', $this->data_to_send, $order_id );
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #62 

**Ticket**:

**Slack Thread**:

---

### Description
This PR adds a filter on payment data to send.
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

### Steps to Test
1. Install Plugin and Setup PayFast Payment Gateway.
2. Add the below code to the theme's functions.php file to append `(THIS IS TESTING)` to `item_name`
```
add_filter( 'woocommerce_gateway_payfast_payment_data_to_send', function( $data_to_send ) {
	// Update item_name. 
	$data_to_send['item_name'] .= '(THIS IS TESTING)';

	return $data_to_send;
});
```
3. Place an order and complete payment with PayFast Payment Gateway.
4. Check the Item name of created order in [Payfast dashboard.](https://sandbox.payfast.co.za/transactions), it should be appended with `(THIS IS TESTING)`

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Add - New filter, `woocommerce_gateway_payfast_payment_data_to_send`, that allows filtering of payment data before it is sent to PayFast.

Closes #62.

