### PR TITLE
add action hook to get token for temporary use

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -642,6 +642,9 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		$order->update_meta_data( 'payfast_amount_net', $data['amount_net'] );
 		$order_id = self::get_order_prop( $order, 'id' );
 
+		// Executes the action hook for getting the token
+		do_action('get_tokenization', $data, $order, $subscriptions);
+
 		// Store token for future subscription deductions.
 		if ( count( $subscriptions ) > 0 && isset( $data['token'] ) ) {
 			if ( $this->_has_renewal_flag( reset( $subscriptions ) ) ) {


### PR DESCRIPTION


**Issue**: #69 


### Description

This PR adds an action hook inside handle_itn_payment_complete() method

Here's how it will work:

1. A user will buy a product on our site through a regular checkout process.
2. Right after the checkout, before order confirmation, we will offer him an upsell offer.
3. This will be a one-click upsell offer, i.e., the buyer will be able to accept the offer through a click of a button, but not go through the checkout process again. Or, he can reject the offer if he wants to.
4. We will then offer him another similar offer.
5. Finally, he will go to the thank you page for order summary and confirmation.

In step 3, we need to use token or Marchant's basic information temporarily. This action will provide us to access $data and $order variables in which we will get our required values.


### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enhancement: Added an action hook inside handle_itn_payment_complete() method

Closes #69.

