### PR TITLE
Added action after handle payment complete ITN from Payfast.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -700,6 +700,17 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 				. 'Order Status Code: ' . self::get_order_prop( $order, 'status' );
 			wp_mail( $debug_email, $subject, $body );
 		}
+
+		/**
+		 * Fires after the handle Payment Complete ITN from Payfast.
+		 *
+		 * @since 1.4.21
+		 *
+		 * @param array             $data          ITN Payload.
+		 * @param WC_Order          $order         Order Object.
+		 * @param WC_Subscription[] $subscriptions Subscription array.
+		 */
+		do_action( 'woocommerce_payfast_handle_itn_payment_complete', $data, $order, $subscriptions );
 	}
 
 	/**

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -702,9 +702,9 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		}
 
 		/**
-		 * Fires after the handle Payment Complete ITN from Payfast.
+		 * Fires after handling the Payment Complete ITN from Payfast.
 		 *
-		 * @since 1.4.21
+		 * @since 1.4.22
 		 *
 		 * @param array             $data          ITN Payload.
 		 * @param WC_Order          $order         Order Object.


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #67 

---

### Description
As requested on #67, This PR adds the `woocommerce_payfast_handle_itn_payment_complete` action hook which fires after handling the payment complete ITN to make the plugin more extendable.
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Add the below code to the theme's functions.php file
```
add_action( 'woocommerce_payfast_handle_itn_payment_complete', 'payfast_itn_payment_complete', 10, 3 );
function payfast_itn_payment_complete( $data, $order, $subscriptions ) {
	// Just add order note to test action hook.
	$order->add_order_note( __( 'Action hook fired successfully after payment complete.', 'theme-text-domain' ) );
}
```
2. Add any product to the cart and proceed to checkout.
3. Place an order and complete payment with `Payfast Payment Gateway`
4. Check order in wp-admin. Verify `Action hook fired successfully after payment complete.` order note is there.

![image](https://user-images.githubusercontent.com/10613171/157884656-3c45ab5d-4e48-4777-8c27-96f354e04398.png)

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Add - `woocommerce_payfast_handle_itn_payment_complete` action hook which fires after handle the payment complete ITN.

Closes #67

