### PR TITLE
Add support for Transaction ID

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -677,11 +677,11 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			} else {
 				/* translators: 1: gross amount 2: payment id */
 				$order->add_order_note( sprintf( __( 'PayFast pre-order product line total paid: R %1$s (%2$s)', 'woocommerce-gateway-payfast' ), $data['amount_gross'], $data['pf_payment_id'] ) );
-				$order->payment_complete();
+				$order->payment_complete( $data['pf_payment_id'] );
 				$this->cancel_pre_order_subscription( $token );
 			}
 		} else {
-			$order->payment_complete();
+			$order->payment_complete( $data['pf_payment_id'] );
 		}
 
 		$debug_email   = $this->get_option( 'debug_email', get_option( 'admin_email' ) );


### PR DESCRIPTION
**Issue**: #72 

**Ticket**: https://wordpress.org/support/topic/needing-to-add-payfast-payment-transaction-id/

---

### Description

Currently the plugin doesn't add a Transaction ID to an order.

WC 2.2 made storing the transaction ID pretty simple,  passing the transaction ID to the method stores the value in the post meta.

For the value I have suggested passing it the Payfast Payment ID, which is declared as `$data['pf_payment_id']`.

### Changelog Entry

> Fixed - Save the Payment's Transaction ID to the order meta.

