### PR TITLE
Fixed production renewal payment failed issue.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1151,7 +1151,9 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 		// Check adhoc bank charge response
 		$results_data = json_decode( $results['body'], true )['data'];
-		if ( $command == 'adhoc' && true !== $results_data['response'] ) {
+
+		// Sandbox ENV returns true(boolean) in response, while Production ENV "true"(string) in response.
+		if ( $command == 'adhoc' && ! ( 'true' === $results_data['response'] || true === $results_data['response'] ) ) {
 			$this->log( "Error posting API request:\n" . print_r( $results_data , true ) );
 
 			$code         = is_array( $results_data['response'] ) ? $results_data['response']['code'] : $results_data['response'];


### PR DESCRIPTION
**Issue**: #94 

---

### Description
This PR fixes the renewal payment failed issue on production env. root cause and background of the issue can be found [here](https://github.com/woocommerce/woocommerce-gateway-payfast/issues/94#issuecomment-1184019340)

PayFast sandbox environment returns success response `true` as **boolean**, while Production environment returns `true` as a **string**. This PR does minor change in condition for considering string and boolean both as a success response to make the plugin work in sandbox and production env.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Create a subscription product
2. Signup to create a subscription using the Payfast payment gateway
3. Process renewal payment (you can follow steps here https://woocommerce.com/document/testing-subscription-renewal-payments/) 
4. Verify renewal payment done properly and subscription remain active.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Fix - Subscription renewal payment failed issue in the production environment. 

Closes #94

