### PR TITLE
Bump WooCommerce tested up to 7.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the official WooCommerce extension to receive payments using the South A
 ## Dependencies
 
 - Requires at least: 5.6
-- Tested up to: 6.0
+- Tested up to: 6.1
 - Requires PHP: 7.0
 
 ### Why choose PayFast?

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -8,7 +8,7 @@
  * Version: 1.5.0
  * Requires at least: 5.6
  * Tested up to: 6.1
- * WC tested up to: 7.1
+ * WC tested up to: 7.3.0
  * WC requires at least: 6.0
  * Requires PHP: 7.0
  */

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 5.6
-Tested up to: 6.0
+Tested up to: 6.1
 Requires PHP: 7.0
 Stable tag: 1.5.0
 License: GPLv3


### PR DESCRIPTION
### Description

This PR bumps WooCommerce tested up to 7.3.0 version.

Also bumps WordPress tested up to 6.1 in the readme files (missing from 3ee16a6e4094f2e340922e70a030866a441a3a39)

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Tweak - Bump WooCommerce tested up to 7.3.0

Closes #117

