### PR TITLE
Bump WooCommerce tested up to 7.4 and Bump minimum supported version for WC and PHP

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   php_compatibility:
-    name: PHP minimum 7.0
+    name: PHP minimum 7.2
     runs-on: ubuntu-latest
 
     steps:
@@ -28,4 +28,4 @@ jobs:
         run: composer install
 
       - name: Run PHP Compatibility
-        run: ./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.0-
+        run: ./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.2-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the official WooCommerce extension to receive payments using the South A
 
 - Requires at least: 5.6
 - Tested up to: 6.1
-- Requires PHP: 7.0
+- Requires PHP: 7.2
 
 ### Why choose Payfast?
 

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -8,9 +8,9 @@
  * Version: 1.5.0
  * Requires at least: 5.6
  * Tested up to: 6.1
- * WC tested up to: 7.3.0
- * WC requires at least: 6.0
- * Requires PHP: 7.0
+ * WC tested up to: 7.4
+ * WC requires at least: 6.8
+ * Requires PHP: 7.2
  */
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "makepot": "wpi18n makepot --domain-path languages --pot-file $npm_package_name.pot --type plugin --main-file $npm_package_name.php --exclude node_modules,tests,docs",
     "phpcs": "./vendor/bin/phpcs *.php includes -p",
-    "phpcompat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.0-"
+    "phpcompat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.2-"
   },
   "config": {
     "wp_org_slug": "woocommerce-payfast-gateway"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,6 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<!-- ensure we are using language features according to supported PHP versions -->
-	<config name="testVersion" value="7.0-"/>
+	<config name="testVersion" value="7.2-"/>
 	<rule ref="PHPCompatibility" />
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, d
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 5.6
 Tested up to: 6.1
-Requires PHP: 7.0
+Requires PHP: 7.2
 Stable tag: 1.5.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #120 

---

### Description
This PR updates the tested up to the WooCommerce version and bumps the minimum supported version for WC and PHP. 

WC tested up to: 7.4
Requires PHP: 7.2
WC requires at least: 6.8

### Steps to Test
Make sure the plugin works fine overall.

- [ ] Set up Payment Gateway with sandbox credentials
- [ ] Place an order with the PayFast payment gateway.
- [ ] Place an order for a subscription product with the PayFast payment gateway and renew the subscription.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry
> Dev - Bump PHP minimum supported version from 7.0 to 7.2.
> Dev - Bump WooCommerce minimum supported version from 6.0 to 6.8.
> Dev - Bump WooCommerce "tested up to" 7.4.

Closes #120

