### PR TITLE
Bump minimum supported version and tested upto for WC and WP

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is the official WooCommerce extension to receive payments using the South A
 
 ## Dependencies
 
-- Requires at least: 5.6
-- Tested up to: 6.1
+- Requires at least: 5.8
+- Tested up to: 6.2
 - Requires PHP: 7.2
 
 ### Why choose Payfast?

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -6,9 +6,9 @@
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Version: 1.5.2
- * Requires at least: 5.6
- * Tested up to: 6.1
- * WC tested up to: 7.4
+ * Requires at least: 5.8
+ * Tested up to: 6.2
+ * WC tested up to: 7.6
  * WC requires at least: 6.8
  * Requires PHP: 7.2
  */

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Payfast Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
-Requires at least: 5.6
-Tested up to: 6.1
+Requires at least: 5.8
+Tested up to: 6.2
 Requires PHP: 7.2
 Stable tag: 1.5.2
 License: GPLv3


### PR DESCRIPTION
**Issue**: #124 

---

### Description

 * Bump WooCommerce "tested up to" version 7.6
 * Bump WordPress minimum supported version from 5.6 to 5.8
 * Bump WordPress "tested up to" version 6.2.

### Steps to Test

- [ ] Set up Payment Gateway with sandbox credentials
- [ ] Place an order with the PayFast payment gateway.
- [ ] Place an order for a subscription product with the PayFast payment gateway and renew the subscription.


### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Dev - Bump WooCommerce "tested up to" version 7.6.
> Dev - Bump WordPress minimum supported version from 5.6 to 5.8.
> Dev - Bump WordPress "tested up to" version 6.2.

Closes #124.

