### PR TITLE
Add all new issues to the 10up project board

### DIFF
--- a/.github/workflows/backlog-automation-issues.yml
+++ b/.github/workflows/backlog-automation-issues.yml
@@ -1,0 +1,17 @@
+name: Add all new and transferred issues to the 10up Triage board.
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/woocommerce/projects/73
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add GH workflow to add new issues to @woocommerce/10up project board: [triage](https://github.com/orgs/woocommerce/projects/73).  Based on work from https://github.com/woocommerce/automatewoo/pull/1287.

Note that we'll need to get the same `ADD_TO_PROJECT_PAT` secret from Bookings added here to ensure this action will run as desired.

### How to test the changes in this Pull Request:

1. Create an issue.
2. Check the [triage project board's](https://github.com/orgs/woocommerce/projects/73) `Needs Triage` column.
3. See created issue in the column.

### Changelog entry

> Dev - Project maintenance automation via GitHub Actions.
