### PR TITLE
Update WC tested upto 7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the official WooCommerce extension to receive payments using the South A
 
 ## Dependencies
 
-- Requires at least: 5.8
+- Requires at least: 6.1
 - Tested up to: 6.2
 - Requires PHP: 7.2
 

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -6,10 +6,10 @@
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
  * Version: 1.5.4
- * Requires at least: 5.8
+ * Requires at least: 6.1
  * Tested up to: 6.2
- * WC tested up to: 7.6
- * WC requires at least: 6.8
+ * WC tested up to: 7.8
+ * WC requires at least: 7.2
  * Requires PHP: 7.2
  */
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Payfast Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
-Requires at least: 5.8
+Requires at least: 6.2
 Tested up to: 6.2
 Requires PHP: 7.2
 Stable tag: 1.5.4

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Payfast Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
-Requires at least: 6.2
+Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.2
 Stable tag: 1.5.4


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #133 

---

### Description

 - Bump WooCommerce "tested up to" version 7.8.
 - Bump WooCommerce minimum supported version from X.X to 7.2.
 - Bump WordPress minimum supported version from X.X to 6.1.

### Steps to Test

Smoke test with WC 7.8:
- [ ] Set up Payment Gateway with sandbox credentials
- [ ] Place an order with the PayFast payment gateway.
- [ ] Place an order for a subscription product with the PayFast payment gateway and renew the subscription.


### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Dev - Bump WooCommerce "tested up to" version 7.8.
> Dev - Bump WooCommerce minimum supported version from 6.8 to 7.2.
> Dev - Bump WordPress minimum supported version from 5.8 to 6.1.

Closes #133 

