### PR TITLE
Handle WP_Error object when return as result from wp_remote_request 

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1153,6 +1153,10 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 		$results = wp_remote_request( $api_endpoint, $api_args );
 
+		if ( is_wp_error( $results ) ) {
+			return $results;
+		}
+
 		// Check Payfast server response
 		if ( 200 !== $results['response']['code'] ) {
 			$this->log( "Error posting API request:\n" . print_r( $results['response'], true ) );


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
As suggested by the issue author, `wp_remote_request` can return `WP_Error`, I added logic to handle it to prevent fatal errors.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

```php
/* @var WC_Gateway_PayFast $payfast */
$payfast = wc()->payment_gateways()->payment_gateways()['payfast'];
echo print_r( $payfast->api_request( 'demo', 'demo', [ 'body' => ''] ), true );
```
1. ~~Display~~ Disable internet connection
2. Run the above code sample locally
3. You should get `WP_Error` object instead of a fatal error.



### Changelog Entry

> Fix - Handle `WP_Error` object when return from `wp_remote_request`.

Closes #136 .

