### PR TITLE
Fix price elements being escaped on the edit order screen

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1581,7 +1581,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			</td>
 			<td width="1%"></td>
 			<td class="total">
-				<?php echo esc_html( wc_price( $fee, array( 'decimals' => 2 ) ) ); ?>
+				<?php echo wp_kses_post( wc_price( $fee, array( 'decimals' => 2 ) ) ); ?>
 			</td>
 		</tr>
 
@@ -1611,7 +1611,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			</td>
 			<td width="1%"></td>
 			<td class="total">
-				<?php echo esc_html( wc_price( $net, array( 'decimals' => 2 ) ) ); ?>
+				<?php echo wp_kses_post( wc_price( $net, array( 'decimals' => 2 ) ) ); ?>
 			</td>
 		</tr>
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Slack Thread**: p1688448816028059/1688426414.640589-slack-C055WHLA98D

---

### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

During testing, an issue was encountered where wc price elements were being escaped. The issue was observed even after rolling back to the live version of PayFast (1.5.4), indicating that it is not related to the latest, planned release. 

The problematic code is `echo esc_html( wc_price( ... ) );`, which incorrectly escapes these wc price elements. To resolve this, the code should be updated to use `echo wp_kses_post( ... );` or a similar alternative. From my look around at other uses, it `wp_kses_post` is considered the standard for handling such scenarios.

This pull request proposes the necessary changes to address the issue and replace the problematic code with the recommended approach. 

**Changes proposed:**
- Replace instances of `echo esc_html( wc_price( ... ) );` with `echo wp_kses_post( ... );`.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Set up PayFast
   - Note you will need to set your store currency to South African Rand.
3. Make a simple purchase of any product using PayFast.
4. Edit the order in the WP Admin.
   - On `trunk` you will see the following escaping. 
   - On this brach it should look correct. 

| `trunk` | This branch |
|--------|--------|
| <img width="447" alt="Screenshot 2023-07-04 at 4 10 56 pm" src="https://github.com/woocommerce/woocommerce-gateway-payfast/assets/8490476/d190df13-d75f-4343-9b4e-f29e7f7eeb9c"> | <img width="477" alt="Screenshot 2023-07-04 at 4 09 46 pm" src="https://github.com/woocommerce/woocommerce-gateway-payfast/assets/8490476/271f281d-afab-4b8e-a168-890a4785f46b"> |

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Fix - Replace escaping of order total price elements on the edit order admin screen.