### PR TITLE
Add workflow to trigger QIT tests on individual PRs

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -37,10 +37,10 @@ jobs:
               run: npm ci --no-optional
 
             - name: Generate ZIP file
-              run: npm run build && rm -rf ./woocommerce-gateway-payfast && unzip woocommerce-gateway-payfast.zip -d ./woocommerce-gateway-payfast
+              run: npm run build && rm -rf ./woocommerce-gateway-payfast && unzip woocommerce-gateway-payfast.zip -d ./woocommerce-payfast-gateway
 
             - name: Use the Upload Artifact GitHub Action
               uses: actions/upload-artifact@v3
               with:
-                  name: woocommerce-gateway-payfast
-                  path: woocommerce-gateway-payfast/
+                  name: woocommerce-payfast-gateway
+                  path: woocommerce-payfast-gateway/

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -37,10 +37,10 @@ jobs:
               run: npm ci --no-optional
 
             - name: Generate ZIP file
-              run: npm run build && rm -rf ./woocommerce-gateway-payfast && unzip woocommerce-gateway-payfast.zip -d ./woocommerce-payfast-gateway
+              run: npm run build && rm -rf ./woocommerce-gateway-payfast && unzip woocommerce-gateway-payfast.zip -d ./woocommerce-gateway-payfast
 
             - name: Use the Upload Artifact GitHub Action
               uses: actions/upload-artifact@v3
               with:
-                  name: woocommerce-payfast-gateway
-                  path: woocommerce-payfast-gateway/
+                  name: woocommerce-gateway-payfast
+                  path: woocommerce-gateway-payfast/

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -1,0 +1,46 @@
+name: Generate ZIP file
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+    generate-zip-file:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Cache node_modules
+              id: cache-node-modules
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+            - name: Setup node version and npm cache
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: '7.4'
+                tools: composer:v2
+
+            - name: Install Node dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: npm ci --no-optional
+
+            - name: Generate ZIP file
+              run: npm run build && rm -rf ./woocommerce-gateway-payfast && unzip woocommerce-gateway-payfast.zip -d ./woocommerce-gateway-payfast
+
+            - name: Use the Upload Artifact GitHub Action
+              uses: actions/upload-artifact@v3
+              with:
+                  name: woocommerce-gateway-payfast
+                  path: woocommerce-gateway-payfast/

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -46,11 +46,10 @@ jobs:
       - name: Download build
         uses: actions/download-artifact@v3
         with:
-          name: woocommerce-payfast-gateway
-          path: woocommerce-payfast-gateway/
+          name: woocommerce-gateway-payfast
 
       - name: Build plugin zip
-        run: zip -r woocommerce-payfast-gateway.zip woocommerce-payfast-gateway
+        run: mv woocommerce-gateway-payfast woocommerce-payfast-gateway && zip -r woocommerce-payfast-gateway.zip woocommerce-payfast-gateway
 
       - name: Set PHP version
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Run activation test
         if: "${{ ( inputs.tests == 'default' || inputs.tests == 'activation' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') }}"
         id: run-activation-test
-        run: ./vendor/bin/qit run:activation ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > activation-result.txt
+        run: ./vendor/bin/qit run:activation woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > activation-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-activation-test.conclusion == 'failure' }}
@@ -79,7 +79,7 @@ jobs:
       - name: Run API test
         if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'api' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') ) && ( success() || failure() ) }}"
         id: run-api-test
-        run: ./vendor/bin/qit run:api ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > api-result.txt
+        run: ./vendor/bin/qit run:api woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > api-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-api-test.conclusion == 'failure' }}
@@ -91,7 +91,7 @@ jobs:
       - name: Run E2E test
         if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'e2e' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') ) && ( success() || failure() ) }}"
         id: run-e2e-test
-        run: ./vendor/bin/qit run:e2e ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > e2e-result.txt
+        run: ./vendor/bin/qit run:e2e woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > e2e-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-e2e-test.conclusion == 'failure' }}
@@ -103,7 +103,7 @@ jobs:
       - name: Run PHPStan test
         if: "${{ inputs.tests == 'phpstan' || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') && ( success() || failure() ) }}"
         id: run-phpstan-test
-        run: ./vendor/bin/qit run:phpstan ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > phpstan-result.txt
+        run: ./vendor/bin/qit run:phpstan woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > phpstan-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
@@ -115,7 +115,7 @@ jobs:
       - name: Run security test
         if: "${{ inputs.tests == 'security' || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') && ( success() || failure() ) }}"
         id: run-security-test
-        run: ./vendor/bin/qit run:security ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > security-result.txt
+        run: ./vendor/bin/qit run:security woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > security-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-security-test.conclusion == 'failure' }}

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: woocommerce-payfast-gateway
+          path: woocommerce-payfast-gateway/
 
       - name: Build plugin zip
         run: zip -r woocommerce-payfast-gateway.zip woocommerce-payfast-gateway

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -49,7 +49,7 @@ jobs:
           name: ${{ github.event.repository.name }}
 
       - name: Build plugin zip
-        run: zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
+        run: zip -r woocommerce-payfast-gateway.zip ${{ github.event.repository.name }}
 
       - name: Set PHP version
         uses: shivammathur/setup-php@v2
@@ -67,7 +67,7 @@ jobs:
       - name: Run activation test
         if: "${{ ( inputs.tests == 'default' || inputs.tests == 'activation' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') }}"
         id: run-activation-test
-        run: ./vendor/bin/qit run:activation woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > activation-result.txt
+        run: ./vendor/bin/qit run:activation woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > activation-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-activation-test.conclusion == 'failure' }}
@@ -79,7 +79,7 @@ jobs:
       - name: Run API test
         if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'api' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') ) && ( success() || failure() ) }}"
         id: run-api-test
-        run: ./vendor/bin/qit run:api woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > api-result.txt
+        run: ./vendor/bin/qit run:api woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > api-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-api-test.conclusion == 'failure' }}
@@ -91,7 +91,7 @@ jobs:
       - name: Run E2E test
         if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'e2e' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') ) && ( success() || failure() ) }}"
         id: run-e2e-test
-        run: ./vendor/bin/qit run:e2e woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > e2e-result.txt
+        run: ./vendor/bin/qit run:e2e woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > e2e-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-e2e-test.conclusion == 'failure' }}
@@ -103,7 +103,7 @@ jobs:
       - name: Run PHPStan test
         if: "${{ inputs.tests == 'phpstan' || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') && ( success() || failure() ) }}"
         id: run-phpstan-test
-        run: ./vendor/bin/qit run:phpstan woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > phpstan-result.txt
+        run: ./vendor/bin/qit run:phpstan woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > phpstan-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
@@ -115,7 +115,7 @@ jobs:
       - name: Run security test
         if: "${{ inputs.tests == 'security' || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') && ( success() || failure() ) }}"
         id: run-security-test
-        run: ./vendor/bin/qit run:security woocommerce-payfast-gateway --zip=${{ github.event.repository.name }}.zip --wait > security-result.txt
+        run: ./vendor/bin/qit run:security woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > security-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-security-test.conclusion == 'failure' }}

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   build:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') }}"
-    uses: woocommerce/woocommerce-gateway-payfast/.github/workflows/generate-zip.yml@feature/qit-workflow # TODO: update branch to trunk before merge.
+    uses: woocommerce/woocommerce-gateway-payfast/.github/workflows/generate-zip.yml@trunk
 
   test:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') }}"

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -46,10 +46,10 @@ jobs:
       - name: Download build
         uses: actions/download-artifact@v3
         with:
-          name: ${{ github.event.repository.name }}
+          name: woocommerce-payfast-gateway
 
       - name: Build plugin zip
-        run: zip -r woocommerce-payfast-gateway.zip ${{ github.event.repository.name }}
+        run: zip -r woocommerce-payfast-gateway.zip woocommerce-payfast-gateway
 
       - name: Set PHP version
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -1,0 +1,125 @@
+name: QIT Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      test:
+        description: 'Test to run'
+        required: true
+        default: 'default'
+        type: choice
+        options:
+          - default
+          - activation
+          - api
+          - e2e
+          - phpstan
+          - security
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches:
+      - trunk
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') }}"
+    uses: woocommerce/woocommerce-gateway-payfast/.github/workflows/generate-zip.yml@feature/qit-workflow # TODO: update branch to trunk before merge.
+
+  test:
+    if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') }}"
+    needs: build
+    name: run
+    runs-on: ubuntu-latest
+
+    env:
+      NO_COLOR: 1
+      QIT_DISABLE_ONBOARDING: yes
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download build
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ github.event.repository.name }}
+
+      - name: Build plugin zip
+        run: zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
+
+      - name: Set PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer:v2
+          coverage: none
+
+      - name: Install QIT via composer
+        run: composer require woocommerce/qit-cli
+
+      - name: Add partner
+        run: ./vendor/bin/qit partner:add --user='${{ secrets.PARTNER_USER }}' --application_password='${{ secrets.PARTNER_SECRET }}'
+
+      - name: Run activation test
+        if: "${{ ( inputs.tests == 'default' || inputs.tests == 'activation' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') }}"
+        id: run-activation-test
+        run: ./vendor/bin/qit run:activation ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > activation-result.txt
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-activation-test.conclusion == 'failure' }}
+        with:
+          header: QIT activation result
+          recreate: true
+          path: activation-result.txt
+
+      - name: Run API test
+        if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'api' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') ) && ( success() || failure() ) }}"
+        id: run-api-test
+        run: ./vendor/bin/qit run:api ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > api-result.txt
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-api-test.conclusion == 'failure' }}
+        with:
+          header: QIT API result
+          recreate: true
+          path: api-result.txt
+
+      - name: Run E2E test
+        if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'e2e' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') ) && ( success() || failure() ) }}"
+        id: run-e2e-test
+        run: ./vendor/bin/qit run:e2e ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > e2e-result.txt
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-e2e-test.conclusion == 'failure' }}
+        with:
+          header: QIT E2E result
+          recreate: true
+          path: e2e-result.txt
+
+      - name: Run PHPStan test
+        if: "${{ inputs.tests == 'phpstan' || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') && ( success() || failure() ) }}"
+        id: run-phpstan-test
+        run: ./vendor/bin/qit run:phpstan ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > phpstan-result.txt
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
+        with:
+          header: QIT PHPStan result
+          recreate: true
+          path: phpstan-result.txt
+
+      - name: Run security test
+        if: "${{ inputs.tests == 'security' || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') && ( success() || failure() ) }}"
+        id: run-security-test
+        run: ./vendor/bin/qit run:security ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > security-result.txt
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-security-test.conclusion == 'failure' }}
+        with:
+          header: QIT security result
+          recreate: true
+          path: security-result.txt


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a first attempt at integrating the [Quality Insights Toolkit](https://woocommerce.github.io/qit-documentation/#/) (QIT) into our standard workflow. At the moment, QIT provides the following tests:

1. End-to-End
2. Activation
3. Security
4. PHPStan
5. API

This PR adds a new GitHub Action workflow with two jobs: one that builds a zip for testing and the other that runs all of the individual tests, depending on label.

The actual tests that will be run are triggered by adding one or more of the following labels (these names can be changed as needed):

- `needs: qit default tests` (will run activation, API and E2E tests. Skips PHPStan and Security for now as those both have lots of noise due to existing code issues)
- `needs: qit activation test`
- `needs: qit api test`
- `needs: qit e2e test`
- `needs: qit phpstan test`
- `needs: qit security test`

This approach allows us to choose which PRs we run these tests on, as well as which tests we want to run.

If a test fails, we utilize the `marocchino/sticky-pull-request-comment` GitHub Action to add a comment to the PR about the test failure details.

### How to test the changes in this Pull Request:

Try adding the various labels as described above and ensure tests run. All tests should pass besides PHPStan and Security

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Dev - Added new GitHub Workflow to run Quality Insights Toolkit tests.
