### PR TITLE
Display admin notice if WooCommerce isn’t active.

### DIFF
--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -91,3 +91,24 @@ function woocommerce_payfast_declare_hpos_compatibility() {
 	}
 }
 add_action( 'before_woocommerce_init', 'woocommerce_payfast_declare_hpos_compatibility' );
+
+/**
+ * Display notice if WooCommerce is not installed.
+ *
+ * @since x.x.x
+ */
+function woocommerce_payfast_missing_wc_notice() {
+	if ( class_exists( 'WooCommerce' ) ) {
+		// Display nothing if WooCommerce is installed and activated.
+		return;
+	}
+
+	echo '<div class="error"><p><strong>';
+	echo sprintf(
+		/* translators: %s WooCommerce download URL link. */
+		esc_html__( 'WooCommerce Payfast Gateway requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-gateway-payfast' ),
+		'<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>'
+	);
+	echo '</strong></p></div>';
+}
+add_action( 'admin_notices', 'woocommerce_payfast_missing_wc_notice' );


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #149

---

### Description

Displays a notice in the admin if the extension is activated without WooCommerce being active.

> **WooCommerce Payfast Gateway requires WooCommerce to be installed and active. You can download [WooCommerce](https://woocommerce.com/) here.**

Nothing is displayed if the `WooCommerce` class is defined.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Activate this extension
2. Deactivate WooCommerce
3. Visit the WordPress dashboard, ensure the notice above is displayed
4. Activate WooCommerce
5. Visit the WordPress dashboard, ensure the notice above is _not_ displayed.


### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Add - Admin notice if this extension is activated without WooCommerce.

Closes #149 .

