### PR TITLE
Bump WordPress Tested up to version to 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the official WooCommerce extension to receive payments using the South A
 ## Dependencies
 
 - Requires at least: 6.1
-- Tested up to: 6.2
+- Tested up to: 6.3
 - Requires PHP: 7.2
 
 ### Why choose Payfast?

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -7,7 +7,7 @@
  * Author URI: http://woocommerce.com/
  * Version: 1.5.7
  * Requires at least: 6.1
- * Tested up to: 6.2
+ * Tested up to: 6.3
  * WC tested up to: 7.8
  * WC requires at least: 7.2
  * Requires PHP: 7.2

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 6.1
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.2
 Stable tag: 1.5.7
 License: GPLv3


### PR DESCRIPTION
### Description

Bump WordPress Tested up to version 6.2 to 6.3

Tested the following scenarios.

- [x] ✅ Verify Debug Email Configuration
- [x] ✅ Verify Enable Logging Functionality
- [x] ✅ Verify Payfast Payment Option Availability
- [x] ✅ Verify Payfast Payment Process
- [x] ✅ Verify Payfast Payment Failure Handling
- [x] ✅ Verify ITN for Successful Payment
- [x] ✅ Test Payfast Payment Method on Block-Based Checkout

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

Test the plugin features with WP 6.3. Follow the above checklist.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Dev - Bump WordPress "tested up to" version from 6.2 to 6.3.

Closes #150.

