### PR TITLE
Bump WooCommerce "tested up to" version 7.9

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   php_compatibility:
-    name: PHP minimum 7.2
+    name: PHP minimum 7.3
     runs-on: ubuntu-latest
 
     steps:
@@ -28,4 +28,4 @@ jobs:
         run: composer install
 
       - name: Run PHP Compatibility
-        run: ./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.2-
+        run: ./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.3-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the official WooCommerce extension to receive payments using the South A
 
 - Requires at least: 6.1
 - Tested up to: 6.2
-- Requires PHP: 7.2
+- Requires PHP: 7.3
 
 ### Why choose Payfast?
 

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -8,9 +8,9 @@
  * Version: 1.5.7
  * Requires at least: 6.1
  * Tested up to: 6.2
- * WC tested up to: 7.8
- * WC requires at least: 7.2
- * Requires PHP: 7.2
+ * WC tested up to: 7.9
+ * WC requires at least: 7.7
+ * Requires PHP: 7.3
  */
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
 		"makepot": "wpi18n makepot --domain-path languages --pot-file $npm_package_name.pot --type plugin --main-file $npm_package_name.php --exclude node_modules,tests,docs",
 		"phpcs": "./vendor/bin/phpcs *.php includes -p",
-		"phpcompat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.2-"
+		"phpcompat": "./vendor/bin/phpcs *.php includes -p --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.3-"
 	},
 	"config": {
 		"wp_org_slug": "woocommerce-payfast-gateway"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,6 @@
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
 	<!-- ensure we are using language features according to supported PHP versions -->
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.3-"/>
 	<rule ref="PHPCompatibility" />
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, d
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 7.2
+Requires PHP: 7.3
 Stable tag: 1.5.7
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
### Description

- Bump WooCommerce "tested up to" version 7.9.
- Bump WooCommerce minimum supported version from 7.2 to 7.7.
- Bump PHP minimum supported version from 7.2 to 7.3.

Tested the following scenarios.

- [x] ✅ Verify Debug Email Configuration
- [x] ✅ Verify Enable Logging Functionality
- [x] ✅ Verify Payfast Payment Option Availability
- [x] ✅ Verify Payfast Payment Process
- [x] ✅ Verify Payfast Payment Failure Handling
- [x] ✅ Verify ITN for Successful Payment
- [x] ✅ Test Payfast Payment Method on Block-Based Checkout

### Steps to Test

Test the plugin features with WC 7.9. Follow the above checklist.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Dev - Bump WooCommerce "tested up to" version 7.9.
> Dev - Bump WooCommerce minimum supported version to 7.7.
> Dev - Bump PHP minimum supported version to 7.3.

Closes #143.
