### PR TITLE
Release 1.5.9

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** PayFast Changelog ***
 
-= 1.5.9 - xxxx-xx-xx =
+= 1.5.9 - 2023-09-18 =
 * Dev - Bump WordPress "tested up to" version from 6.2 to 6.3.
 * Dev - Bump WooCommerce "tested up to" version 7.9.
 * Dev - Bump WooCommerce minimum supported version to 7.7.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** PayFast Changelog ***
 
+= 1.5.9 - xxxx-xx-xx =
+* Dev - Bump WordPress "tested up to" version from 6.2 to 6.3.
+* Dev - Bump WooCommerce "tested up to" version 7.9.
+* Dev - Bump WooCommerce minimum supported version to 7.7.
+* Dev - Bump PHP minimum supported version to 7.3.
+
 = 1.5.8 - 2023-08-29 =
 * Add - Admin notice if this extension is activated without WooCommerce.
 

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -5,7 +5,7 @@
  * Description: Receive payments using the South African Payfast payments provider.
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
- * Version: 1.5.8
+ * Version: 1.5.9
  * Requires at least: 6.1
  * Tested up to: 6.3
  * Tested up to: 6.2
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GATEWAY_PAYFAST_VERSION', '1.5.8' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GATEWAY_PAYFAST_VERSION', '1.5.9' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GATEWAY_PAYFAST_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'WC_GATEWAY_PAYFAST_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-gateway-payfast",
-	"version": "1.5.8",
+	"version": "1.5.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce-gateway-payfast",
 	"title": "WooCommerce Gateway Payfast",
-	"version": "1.5.8",
+	"version": "1.5.9",
 	"license": "GPL-3.0",
 	"homepage": "https://wordpress.org/plugins/woocommerce-payfast-gateway/",
 	"repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 6.1
 Tested up to: 6.3
 Requires PHP: 7.3
-Stable tag: 1.5.8
+Stable tag: 1.5.9
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -38,7 +38,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 1.5.9 - xxxx-xx-xx =
+= 1.5.9 - 2023-09-18 =
 * Dev - Bump WordPress "tested up to" version from 6.2 to 6.3.
 * Dev - Bump WooCommerce "tested up to" version 7.9.
 * Dev - Bump WooCommerce minimum supported version to 7.7.

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,12 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 1.5.9 - xxxx-xx-xx =
+* Dev - Bump WordPress "tested up to" version from 6.2 to 6.3.
+* Dev - Bump WooCommerce "tested up to" version 7.9.
+* Dev - Bump WooCommerce minimum supported version to 7.7.
+* Dev - Bump PHP minimum supported version to 7.3.
+
 = 1.5.8 - 2023-08-29 =
 * Add - Admin notice if this extension is activated without WooCommerce.
 


### PR DESCRIPTION
```
= 1.5.9 - 2023-09-18 =
* Dev - Bump WordPress "tested up to" version from 6.2 to 6.3.
* Dev - Bump WooCommerce "tested up to" version 7.9.
* Dev - Bump WooCommerce minimum supported version to 7.7.
* Dev - Bump PHP minimum supported version to 7.3.
```