### PR TITLE
Declare add-on compatible with product editor

### DIFF
--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -12,7 +12,6 @@
  * WC requires at least: 8.1
  * Requires PHP: 7.3
  */
-use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -81,16 +80,29 @@ function woocommerce_payfast_woocommerce_blocks_support() {
 }
 
 /**
- * Declares support for HPOS.
+ * Declares compatibility with Woocommerce features.
  *
+ * List of features:
+ * - custom_order_tables
+ * - product_block_editor
+ *
+ * @since x.x.x Rename function
  * @return void
  */
-function woocommerce_payfast_declare_hpos_compatibility() {
-	if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+function woocommerce_payfast_declare_feature_compatibility() {
+	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+			'custom_order_tables',
+			__FILE__
+		);
+
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+			'product_block_editor',
+			__FILE__
+		);
 	}
 }
-add_action( 'before_woocommerce_init', 'woocommerce_payfast_declare_hpos_compatibility' );
+add_action( 'before_woocommerce_init', 'woocommerce_payfast_declare_feature_compatibility' );
 
 /**
  * Display notice if WooCommerce is not installed.

--- a/gateway-payfast.php
+++ b/gateway-payfast.php
@@ -15,8 +15,6 @@
  * @package WooCommerce Gateway Payfast
  */
 
-use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
-
 defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GATEWAY_PAYFAST_VERSION', '1.6.0' ); // WRCS: DEFINED_VERSION.


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This add-on seamlessly integrates Woocommerce with the PayFast payment gateway. However, it's essential to mention that it currently does not offer product-level settings. We can confidently declare its compatibility with the product editor.

Closes #177 .

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

- The admin should be able to create the product with the new product editor.
- The admin should be able to create the product with a classic product editor.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Declare add-on compatibility with Product Editor.