### PR TITLE
Do not redirect users after navigating back to order page.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -483,6 +483,25 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 				'</a>
 				<script type="text/javascript">
 					jQuery(function(){
+						// Feature detect.
+						if (
+							typeof PerformanceNavigationTiming !== "undefined" &&
+							typeof window.performance !== "undefined" &&
+							typeof performance.getEntriesByType === "function"
+						) {
+							var isBackForward = false;
+							var entries = performance.getEntriesByType("navigation");
+							entries.forEach((entry) => {
+								if (entry.type === "back_forward") {
+									isBackForward = true;
+								}
+							});
+							if (isBackForward) {
+								// Do not submit form on back or forward.
+								return;
+							}
+						}
+
 						jQuery("body").block(
 							{
 								message: "' . esc_html__( 'Thank you for your order. We are now redirecting you to Payfast to make payment.', 'woocommerce-gateway-payfast' ) . '",


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This uses the performance navigation API to determine whether a user has navigated back from the payfast payment page to the WooCommerce Pay for order page.

If a user has navigated back, it prevents the JavaScript redirect from initiating and allows the user to pay or cancel the order via the buttons placed at the bottom of the screen.

**Risks**

It's using the `PerformanceNavigationTiming` API to sniff whether a user has navigated to the page via the back or forward buttons (it's not possible to determine the exact one of the two). If browser manufacturers decide in the future that this sort of thing is an abuse of the API then the code may stop working and need to be removed.

I don't think this use case is an abuse of the API but I can foresee a situation in which the spammier type of advertising service may start abusing it and prevent the rest of the web from having nice things. Again.

Closes #3.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

This will need testing in multiple browser but the reported bug in #3 relates to iOS Safari so be sure to test in that.

1. Set the store's currency to South African Rand.
2. Create a simple product of R20.00
3. Go through checkout process using Payfast
4. Once you are redirected to the Payfast gateway page, press back in your browser
5. Two things:
   * You should not be redirected to the gateway page a second time.
   * You should not see the redirection overlay blocking access to the page.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Allow navigation back from PayFast gateway payment page.