### PR TITLE
Add readme.md file for e2e tests

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,7 +20,7 @@ PAYFAST_PASSPHRASE=********
 4. Add environment variables to the `/tests/e2e/config/.env` file (as mentioned above).
 5. Run `npm run test:e2e-local`.
 
-### Dependencies for Github testing
+### Dependencies for Github Action testing
 - Add bot token to Github,
 ```
 gh secret set BOT_GITHUB_TOKEN --app actions --repo=woocommerce/woocommerce-gateway-payfast

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,30 @@
+## E2E Tests
+
+This directory contains end-to-end tests for the project, utilizing [Playwright](https://playwright.dev) to run tests in Chromium browser.
+
+### Pre-requisites
+- Create [sandbox PayFast](https://sandbox.payfast.co.za/) account which used for test payments.
+
+### Dependencies for local testing
+- Add `.env` file with PayFast credentials in `./tests/e2e/config` directory.
+```
+PAYFAST_MERCHANT_ID=********
+PAYFAST_MERCHANT_KEY=********
+PAYFAST_PASSPHRASE=********
+```
+
+**Note**: Use `npm run test:e2e-local` to run tests locally.
+
+### Dependencies for Github testing
+- Add bot token to Github,
+```
+gh secret set BOT_GITHUB_TOKEN --app actions --repo=woocommerce/woocommerce-gateway-payfast
+```
+- Add PayFast credentials to Github.
+```
+gh secret set PAYFAST_MERCHANT_ID --app actions --repo=woocommerce/woocommerce-gateway-payfast
+gh secret set PAYFAST_MERCHANT_KEY --app actions --repo=woocommerce/woocommerce-gateway-payfast
+gh secret set PAYFAST_PASSPHRASE --app actions --repo=woocommerce/woocommerce-gateway-payfast
+```
+
+**Note**: Add `needs: e2e testing` to pull request to run e2e tests. 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -27,4 +27,10 @@ gh secret set PAYFAST_MERCHANT_KEY --app actions --repo=woocommerce/woocommerce-
 gh secret set PAYFAST_PASSPHRASE --app actions --repo=woocommerce/woocommerce-gateway-payfast
 ```
 
-**Note**: Add `needs: e2e testing` to pull request to run e2e tests. 
+**Note**:
+- Add the GitHub secret only if it doesn't already exist. Utilize the following command to check if the secret exists:
+```
+gh secret list --app actions --repo=woocommerce/woocommerce-gateway-payfast
+```
+- Add `needs: e2e testing` to pull request to run e2e tests. 
+

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,7 +13,12 @@ PAYFAST_MERCHANT_KEY=********
 PAYFAST_PASSPHRASE=********
 ```
 
-**Note**: Use `npm run test:e2e-local` to run tests locally.
+### Run E2E tests in local
+1. Run `npm install`.
+2. Run `npx playwright install`.
+3. Run `npm run env:start-local`  (Note: Please start Docker before executing this command).
+4. Add environment variables to the `/tests/e2e/config/.env` file (as mentioned above).
+5. Run `npm run test:e2e-local`.
 
 ### Dependencies for Github testing
 - Add bot token to Github,

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -37,5 +37,7 @@ gh secret set PAYFAST_PASSPHRASE --app actions --repo=woocommerce/woocommerce-ga
 ```
 gh secret list --app actions --repo=woocommerce/woocommerce-gateway-payfast
 ```
-- Add `needs: e2e testing` to pull request to run e2e tests. 
+### Run E2E tests in the pull request
+
+- Add the `needs: e2e testing` label to the pull request; it will initiate the E2E test GitHub action to run tests against the PR.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The E2E test conducts transactions that necessitate PayFast credentials. Before running the test locally or on GitHub, following specific steps outlined in the README.md file located in the `.\tests\e2e` directory is crucial.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
The `README.md` file must include essential information for running tests both locally and on GitHub.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - Readme.md file for e2e tests