### PR TITLE
upkeep/176: Declare compatibility with WooCommerce Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ For help setting up and configuring, please refer to our [user guide](https://do
 
 If you get stuck, you can ask for help in the Plugin Forum.
 
+### Compatibility
+
+This extension is compatible with:
+- [WooCommerce Blocks](https://woo.com/products/woocommerce-gutenberg-products-block/)
+
 ## License
 [GPLv3](https://www.gnu.org/licenses/gpl-3.0.html)
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** PayFast Changelog ***
 
+= 1.6.1 - TBD =
+* Dev - Declare compatibility with WooCommerce Blocks
+
 = 1.6.0 - 2023-11-22 =
 * Dev - Add Playwright end-to-end tests.
 * Dev - Update default behavior to use a block-based cart and checkout in E2E tests.

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 1.6.1 - TBD =
+* Dev - Declare compatibility with WooCommerce Blocks
+
 = 1.6.0 - 2023-11-22 =
 * Dev - Add Playwright end-to-end tests.
 * Dev - Update default behavior to use a block-based cart and checkout in E2E tests.


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #176

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Declare compatibility with WooCommerce Blocks.