### PR TITLE
Compatibility testing with Woo 8.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Payfast Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
-Requires at least: 6.2
+Requires at least: 6.3
 Tested up to: 6.4
 Requires PHP: 7.4
 Stable tag: 1.6.1

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -6,10 +6,10 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Version: 1.6.1
- * Requires at least: 6.2
+ * Requires at least: 6.3
  * Tested up to: 6.4
- * WC requires at least: 8.2
- * WC tested up to: 8.4
+ * WC requires at least: 8.3
+ * WC tested up to: 8.5
  * Requires PHP: 7.4
  * PHP tested up to: 8.3
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.5.
- Bump WooCommerce minimum supported version to 8.3.
- Bump WordPress minimum supported version to 6.3.

Closes [#485](https://github.com/woocommerce/woocommerce-gateway-payfast/issues/194) 

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR with WC 8.5
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.5.
> Dev - Bump WooCommerce minimum supported version to 8.3.
> Dev - Bump WordPress minimum supported version to 6.3.

