### PR TITLE
Compatibility testing with Woo 8.6

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,7 +92,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: ['needs: testing']
+              name: ['needs: e2e testing']
             })
             github.rest.issues.addLabels({
               issue_number: context.issue.number,

--- a/tests/e2e/specs/admin/edit-settings.test.js
+++ b/tests/e2e/specs/admin/edit-settings.test.js
@@ -191,7 +191,7 @@ test.describe( 'Verify payfast setting - @foundational', async () => {
 
 		// Verify: log create.
 		await adminPage.goto( '/wp-admin/admin.php?page=wc-status&tab=logs' );
-		const woocommerceLogFiles = await adminPage.locator( 'select[name="log_file"] option', {
+		const woocommerceLogFiles = await adminPage.locator( 'table.log-files a.row-title', {
 			hasText: 'payfast',
 		} );
 		await expect( await woocommerceLogFiles.count() ).not.toBe( 0 );

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -8,8 +8,8 @@
  * Version: 1.6.1
  * Requires at least: 6.3
  * Tested up to: 6.4
- * WC requires at least: 8.3
- * WC tested up to: 8.5
+ * WC requires at least: 8.4
+ * WC tested up to: 8.6
  * Requires PHP: 7.4
  * PHP tested up to: 8.3
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.6.
- Bump WooCommerce minimum supported version to 8.4.

Closes https://github.com/woocommerce/woocommerce-gateway-payfast/issues/197

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR with WC 8.6
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.6.
> Dev - Bump WooCommerce minimum supported version to 8.4.

