### PR TITLE
Compatibility testing with Woo 8.7 and WordPress 6.5 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,4 @@ composer.lock export-ignore
 .prettierignore export-ignore
 .nvmrc export-ignore
 .wp-env.json export-ignore
+.wp-env.override.json export-ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,12 +44,17 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium
 
+      - name: Set the core version
+        if: "${{ contains(github.event.pull_request.labels.*.name, 'needs: WP RC test') }}"
+        id: run-rc-test
+        run: ./tests/e2e/bin/set-core-version.js WordPress/WordPress#master
+
       - name: Install required WP plugins
         run: |
           URL_CONFIG="url.https://${{ secrets.BOT_GITHUB_TOKEN }}:x-oauth-basic@github.com/.insteadOf git@github.com:"
           git config --global $URL_CONFIG
           npm run env:install-plugins
-          
+
           git config --global --unset $URL_CONFIG
 
       - name: Setup WP environment

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ screenshots/
 /assets/**/*.min.js
 /assets/**/*.css
 .idea
+.wp-env.override.json
 
 # Ignore all log files except for .htaccess
 /logs/*

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is the official WooCommerce extension to receive payments using the South A
 
 ## Dependencies
 
-- Requires at least: 6.2
-- Tested up to: 6.4
+- Requires at least: 6.3
+- Tested up to: 6.5
 - Requires PHP: 7.4
 
 ### Why choose Payfast?

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes, dwainm, laurendavissmith001
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 6.3
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 7.4
 Stable tag: 1.6.1
 License: GPLv3

--- a/tests/e2e/bin/set-core-version.js
+++ b/tests/e2e/bin/set-core-version.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const fs = require( 'fs' );
+const { exit } = require( 'process' );
+
+const path = `${ process.cwd() }/.wp-env.override.json`;
+
+// eslint-disable-next-line import/no-dynamic-require
+const config = fs.existsSync( path ) ? require( path ) : {};
+
+const args = process.argv.slice( 2 );
+
+if ( args.length === 0 ) exit( 0 );
+
+if ( args[ 0 ] === 'latest' ) {
+	if ( fs.existsSync( path ) ) {
+		fs.unlinkSync( path );
+	}
+	exit( 0 );
+}
+
+config.core = args[ 0 ];
+
+// eslint-disable-next-line no-useless-escape
+if ( ! config.core.match( /^WordPress\/WordPress\#/ ) ) {
+	config.core = `WordPress/WordPress#${ config.core }`;
+}
+
+try {
+	fs.writeFileSync( path, JSON.stringify( config ) );
+} catch ( err ) {
+	// eslint-disable-next-line no-console
+	console.error( err );
+}

--- a/tests/e2e/specs/admin/activate-extension.test.js
+++ b/tests/e2e/specs/admin/activate-extension.test.js
@@ -1,34 +1,24 @@
 /**
  * WordPress dependencies
  */
-const {test, expect} = require( '@playwright/test' );
+const { test, expect } = require('@playwright/test');
 
-test.describe( 'Store admin can login and make sure add-on is activated - @foundational',
-	async ( selector, options ) => {
+test.describe(
+	'Store admin can login and make sure add-on is activated - @foundational',
+	async (selector, options) => {
 		// Set admin as logged-in user.
-		test.use( {storageState: process.env.ADMINSTATE} );
+		test.use({ storageState: process.env.ADMINSTATE });
 
-		test( 'Plugin Activation Without Errors', async ( {page} ) => {
-			await page.goto( '/wp-admin/plugins.php' );
+		test('Plugin Activation Without Errors', async ({ page }) => {
+			await page.goto('/wp-admin/plugins.php');
 
 			// Addon is active by default in the test environment, so we need to validate that it is activated.
-			await expect( page.getByRole( 'link',
-				{name: 'Deactivate WooCommerce Payfast Gateway', exact: true} ) ).toBeVisible();
-		} );
-
-		test( 'Plugin display a admin notice not if WooCommerce is not active', async ( {page} ) => {
-			await page.goto( '/wp-admin/plugins.php' );
-
-			// Deactivate WooCommerce.
-			await page.getByRole( 'link', {name: 'Deactivate WooCommerce', exact: true} ).click();
-
-			const adminNotices = await page.locator( 'div.error', {
-				hasText: 'WooCommerce Payfast Gateway requires WooCommerce to be installed and active'
-			} );
-
-			await expect( await adminNotices.count() ).not.toBe( 0 );
-
-			// Activate WooCommerce.
-			await page.getByRole( 'link', {name: 'Activate WooCommerce', exact: true} ).click();
-		} );
-	} );
+			await expect(
+				page.getByRole('link', {
+					name: 'Deactivate WooCommerce Payfast Gateway',
+					exact: true,
+				})
+			).toBeVisible();
+		});
+	}
+);

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -1,15 +1,16 @@
 <?php
 /**
  * Plugin Name: WooCommerce Payfast Gateway
+ * Requires Plugins: woocommerce
  * Plugin URI: https://woocommerce.com/products/payfast-payment-gateway/
  * Description: Receive payments using the South African Payfast payments provider.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Version: 1.6.1
  * Requires at least: 6.3
- * Tested up to: 6.4
- * WC requires at least: 8.4
- * WC tested up to: 8.6
+ * Tested up to: 6.5
+ * WC requires at least: 8.5
+ * WC tested up to: 8.7
  * Requires PHP: 7.4
  * PHP tested up to: 8.3
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.7.
- Bump WooCommerce minimum supported version to 8.5
- Bump WordPress "tested up to" version 6.5.
- Bump WordPress minimum supported version to 6.3. 

Closes https://github.com/woocommerce/woocommerce-gateway-payfast/issues/203

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.7.
> Dev - Bump WooCommerce minimum supported version to 8.5
> Dev - Bump WordPress "tested up to" version 6.5.
> Dev - Bump WordPress minimum supported version to 6.3.

