### PR TITLE
Compatibility testing with Woo 8.8

### DIFF
--- a/tests/e2e/specs/payment-flow/subscription-payment.test.js
+++ b/tests/e2e/specs/payment-flow/subscription-payment.test.js
@@ -52,7 +52,7 @@ test.describe( 'Verify Payfast Subscription Payment Process - @foundational', as
 		const payfastPaymentMethod = await checkoutBlock.locator(
 			'label[for="radio-control-wc-payment-method-options-payfast"]' );
 		await payfastPaymentMethod.click();
-		await checkoutBlock.getByRole( 'button', {name: 'Place Order'} ).click();
+		await checkoutBlock.locator( 'button.wc-block-components-checkout-place-order-button' ).click();
 		await waitForURL;
 
 		// Pay on Payfast checkout page.

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -9,8 +9,8 @@
  * Version: 1.6.2
  * Requires at least: 6.3
  * Tested up to: 6.5
- * WC requires at least: 8.5
- * WC tested up to: 8.7
+ * WC requires at least: 8.6
+ * WC tested up to: 8.8
  * Requires PHP: 7.4
  * PHP tested up to: 8.3
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 8.8
- Bump WooCommerce minimum supported version to 8.6


Closes https://github.com/woocommerce/woocommerce-gateway-payfast/issues/213

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 
3. Manual Test - The plugin should give Notice when using an unsupported version of WooCommerce and WordPress. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 8.8.
> Dev - Bump WooCommerce minimum supported version to 8.6.

