### PR TITLE
Decode HTML entity encoding in the site name before sending data to Payfast.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -394,7 +394,8 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 	 * @return void
 	 */
 	public function generate_payfast_form( $order_id ) {
-		$order = wc_get_order( $order_id );
+		$order     = wc_get_order( $order_id );
+		$site_name = html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES, get_bloginfo( 'charset' ) );
 		// Construct variables for post.
 		$this->data_to_send = array(
 			// Merchant details.
@@ -412,9 +413,9 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			// Item details.
 			'm_payment_id'     => ltrim( $order->get_order_number(), _x( '#', 'hash before order number', 'woocommerce-gateway-payfast' ) ),
 			'amount'           => $order->get_total(),
-			'item_name'        => get_bloginfo( 'name' ) . ' - ' . $order->get_order_number(),
+			'item_name'        => $site_name . ' - ' . $order->get_order_number(),
 			/* translators: 1: blog info name */
-			'item_description' => sprintf( esc_html__( 'New order from %s', 'woocommerce-gateway-payfast' ), get_bloginfo( 'name' ) ),
+			'item_description' => sprintf( esc_html__( 'New order from %s', 'woocommerce-gateway-payfast' ), $site_name ),
 
 			// Custom strings.
 			'custom_str1'      => self::get_order_prop( $order, 'order_key' ),


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
The PR addresses the signature mismatch error. Upon investigation, I discovered that the mismatch was due to HTML entity encoding in the site/blog name for special characters. We are sending the blog name in the item name and item description values, and the signature is being generated based on the encoded HTML entity. However, the value in the form is sent with decoded HTML entity, causing the mismatch. This PR resolves the issue by generating the signature based on the decoded HTML entity.

### Steps to test the changes in this Pull Request:
1. Set the site title to something that uses a special character, e.g., `Bob's Site` (Please try different combinations).
2. Add a product to the cart and place an order.
3. Verify that the order has been placed successfully without any issues.

### Changelog entry
> Fix - Resolved signature mismatch error caused by HTML entity encoding in site/blog name.