### PR TITLE
Use urlencode

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1,4 +1,4 @@
-<?php
+	<?php
 /**
  * Payfast Payment Gateway
  *
@@ -419,7 +419,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 			// Custom strings.
 			'custom_str1'      => self::get_order_prop( $order, 'order_key' ),
-			'custom_str2'      => 'WooCommerce/' . WC_VERSION . '; ' . get_site_url(),
+			'custom_str2'      => 'WooCommerce/' . WC_VERSION . '; ' . urlencode(get_site_url()),
 			'custom_str3'      => self::get_order_prop( $order, 'id' ),
 			'source'           => 'WooCommerce-Free-Plugin',
 		);

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -419,7 +419,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 			// Custom strings.
 			'custom_str1'      => self::get_order_prop( $order, 'order_key' ),
-			'custom_str2'      => 'WooCommerce/' . WC_VERSION . '; ' . urlencode( get_site_url() ),
+			'custom_str2'      => 'WooCommerce/' . WC_VERSION . '; ' . rawurlencode( get_site_url() ),
 			'custom_str3'      => self::get_order_prop( $order, 'id' ),
 			'source'           => 'WooCommerce-Free-Plugin',
 		);

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 /**
  * Payfast Payment Gateway
  *
@@ -419,7 +419,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 			// Custom strings.
 			'custom_str1'      => self::get_order_prop( $order, 'order_key' ),
-			'custom_str2'      => 'WooCommerce/' . WC_VERSION . '; ' . urlencode(get_site_url()),
+			'custom_str2'      => 'WooCommerce/' . WC_VERSION . '; ' . urlencode( get_site_url() ),
 			'custom_str3'      => self::get_order_prop( $order, 'id' ),
 			'source'           => 'WooCommerce-Free-Plugin',
 		);


### PR DESCRIPTION
Use urlencode in place of get_site_url

### All Submissions:

<!-- Mark completed items with an [x] -->
* [x ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Use urlencode instead of simply returning the site url

### Steps to test the changes in this Pull Request:
Activate plugin and process a transaction 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Use `rawurlencode` around the call to `get_site_url` to ensure things are encoded properly.