### PR TITLE
Change plugin URL to support symlinking

### DIFF
--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -20,7 +20,7 @@
 defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GATEWAY_PAYFAST_VERSION', '1.6.5' ); // WRCS: DEFINED_VERSION.
-define( 'WC_GATEWAY_PAYFAST_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
+define( 'WC_GATEWAY_PAYFAST_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'WC_GATEWAY_PAYFAST_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 
 /**


### PR DESCRIPTION
This should fix https://github.com/woocommerce/woocommerce-gateway-payfast/issues/161 and https://github.com/woocommerce/woocommerce-gateway-payfast/issues/202

### All Submissions:

<!-- Mark completed items with an [x] -->
* [x ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Change the relative URL for the plugin. 

Closes #161 and #202  .

### Steps to test the changes in this Pull Request:

Install latest version on symlink. 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Update defined plugin URL for symlinking compatibility. 