### PR TITLE
Exclude the @since existence check sniff rule

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,4 +30,9 @@
 	<rule ref="PHPCompatibilityWP">
 		<exclude name="PHPCompatibilityWP"/>
 	</rule>
+
+	<rule ref="WooCommerce.Commenting">
+	<!-- It wants @since to contain defined version and does not allow just x.x.x -->
+	<exclude name="WooCommerce.Commenting.CommentHooks.MissingSinceVersionComment"/>
+	</rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -32,7 +32,7 @@
 	</rule>
 
 	<rule ref="WooCommerce.Commenting">
-	<!-- It wants @since to contain defined version and does not allow just x.x.x -->
-	<exclude name="WooCommerce.Commenting.CommentHooks.MissingSinceVersionComment"/>
+		<!-- It wants @since to contain defined version and does not allow just x.x.x -->
+		<exclude name="WooCommerce.Commenting.CommentHooks.MissingSinceVersionComment"/>
 	</rule>
 </ruleset>


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR excludes the `@since` existence check sniff to avoid errors when x.x.x is set.


Closes #235 

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

See the reproduction steps in the linked Issue.


<img width="680" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-payfast/assets/67687255/7462f220-7914-463a-a684-9a49d12b1ce8">


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Exclude the Woo Comment Hook `@since` sniff.