### PR TITLE
Bump WordPress Tested up to version 6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This is the official WooCommerce extension to receive payments using the South A
 
 ## Dependencies
 
-- Requires at least: 6.3
-- Tested up to: 6.5
+- Requires at least: 6.4
+- Tested up to: 6.6
 - Requires PHP: 7.4
 
 ### Why choose Payfast?

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Payfast Gateway ===
 Contributors: woocommerce, automattic
 Tags: credit card, payfast, payment request, woocommerce, automattic
-Requires at least: 6.3
-Tested up to: 6.5
+Requires at least: 6.4
+Tested up to: 6.6
 Requires PHP: 7.4
 Stable tag: 1.6.5
 License: GPLv3

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Version: 1.6.5
  * Requires at least: 6.4
- * Tested up to: 6.5
+ * Tested up to: 6.6
  * WC requires at least: 8.8
  * WC tested up to: 9.0
  * Requires PHP: 7.4


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Bump WordPress Tested up to version 6.5 to 6.6
- Bump WordPress Requires at least 6.3 to 6.4


Closes https://github.com/woocommerce/woocommerce-gateway-payfast/issues/237


### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.6.
> Dev - Bump WordPress minimum supported version to 6.4.

