### PR TITLE
Fix the QIT Woo E2E tests and add new PHPCompat and Malware tests.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
       - name: Node cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -111,7 +111,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: npm run test:e2e
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -9,11 +9,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Cache node_modules
               id: cache-node-modules
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               env:
                   cache-name: cache-node-modules
               with:
@@ -21,7 +21,7 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Setup node version and npm cache
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version-file: '.nvmrc'
                   cache: 'npm'
@@ -40,7 +40,7 @@ jobs:
               run: npm run build && rm -rf ./woocommerce-gateway-payfast && unzip woocommerce-gateway-payfast.zip -d ./woocommerce-gateway-payfast
 
             - name: Use the Upload Artifact GitHub Action
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: woocommerce-gateway-payfast
                   path: woocommerce-gateway-payfast/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 🚚 Get latest code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: ⚙️ Install Utilities
       run: sudo apt-get update && sudo apt-get install -y lftp --allow-downgrades;

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   build:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"
-    uses: woocommerce/woocommerce-gateway-payfast/.github/workflows/generate-zip.yml@fix/236
+    uses: woocommerce/woocommerce-gateway-payfast/.github/workflows/generate-zip.yml@trunk
 
   test:
     if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -26,11 +26,11 @@ permissions:
 
 jobs:
   build:
-    if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') }}"
-    uses: woocommerce/woocommerce-gateway-payfast/.github/workflows/generate-zip.yml@trunk
+    if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"
+    uses: woocommerce/woocommerce-gateway-payfast/.github/workflows/generate-zip.yml@fix/236
 
   test:
-    if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') }}"
+    if: "${{ ( inputs.test != '' && inputs.test != 'none' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit activation test') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') }}"
     needs: build
     name: run
     runs-on: ubuntu-latest
@@ -105,6 +105,18 @@ jobs:
         id: run-phpstan-test
         run: ./vendor/bin/qit run:phpstan woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > phpstan-result.txt
 
+      - name: Run PHPCompat test
+        if: "${{ inputs.tests == 'phpcompat' || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') && ( success() || failure() ) }}"
+        id: run-phpcompat-test
+        run: ./vendor/bin/qit run:phpcompatibility ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > phpcompat-result.txt
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-phpcompat-test.conclusion == 'failure' }}
+        with:
+          header: QIT PHPCompat result
+          recreate: true
+          path: phpcompat-result.txt
+
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
         with:
@@ -123,3 +135,15 @@ jobs:
           header: QIT security result
           recreate: true
           path: security-result.txt
+
+      - name: Run malware test
+        if: "${{ inputs.tests == 'malware' || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') && ( success() || failure() ) }}"
+        id: run-malware-test
+        run: ./vendor/bin/qit run:malware ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > malware-result.txt
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-malware-test.conclusion == 'failure' }}
+        with:
+          header: QIT malware result
+          recreate: true
+          path: malware-result.txt

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -104,11 +104,18 @@ jobs:
         if: "${{ inputs.tests == 'phpstan' || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') && ( success() || failure() ) }}"
         id: run-phpstan-test
         run: ./vendor/bin/qit run:phpstan woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > phpstan-result.txt
+        
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
+        with:
+          header: QIT PHPStan result
+          recreate: true
+          path: phpstan-result.txt
 
       - name: Run PHPCompat test
         if: "${{ inputs.tests == 'phpcompat' || contains(github.event.pull_request.labels.*.name, 'needs: qit phpcompat test') && ( success() || failure() ) }}"
         id: run-phpcompat-test
-        run: ./vendor/bin/qit run:phpcompatibility ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > phpcompat-result.txt
+        run: ./vendor/bin/qit run:phpcompatibility woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > phpcompat-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-phpcompat-test.conclusion == 'failure' }}
@@ -116,13 +123,6 @@ jobs:
           header: QIT PHPCompat result
           recreate: true
           path: phpcompat-result.txt
-
-      - uses: marocchino/sticky-pull-request-comment@v2
-        if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
-        with:
-          header: QIT PHPStan result
-          recreate: true
-          path: phpstan-result.txt
 
       - name: Run security test
         if: "${{ inputs.tests == 'security' || contains(github.event.pull_request.labels.*.name, 'needs: qit security test') && ( success() || failure() ) }}"
@@ -139,7 +139,7 @@ jobs:
       - name: Run malware test
         if: "${{ inputs.tests == 'malware' || contains(github.event.pull_request.labels.*.name, 'needs: qit malware test') && ( success() || failure() ) }}"
         id: run-malware-test
-        run: ./vendor/bin/qit run:malware ${{ github.event.repository.name }} --zip=${{ github.event.repository.name }}.zip --wait > malware-result.txt
+        run: ./vendor/bin/qit run:malware woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > malware-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-malware-test.conclusion == 'failure' }}

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: woocommerce-gateway-payfast
 

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run API test
         if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'api' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit api test') ) && ( success() || failure() ) }}"
         id: run-api-test
-        run: ./vendor/bin/qit run:api woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > api-result.txt
+        run: ./vendor/bin/qit run:woo-api woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > api-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-api-test.conclusion == 'failure' }}
@@ -91,7 +91,7 @@ jobs:
       - name: Run E2E test
         if: "${{ ( ( inputs.tests == 'default' || inputs.tests == 'e2e' ) || contains(github.event.pull_request.labels.*.name, 'needs: qit default tests') || contains(github.event.pull_request.labels.*.name, 'needs: qit e2e test') ) && ( success() || failure() ) }}"
         id: run-e2e-test
-        run: ./vendor/bin/qit run:e2e woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > e2e-result.txt
+        run: ./vendor/bin/qit run:woo-e2e woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > e2e-result.txt
 
       - uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ failure() && steps.run-e2e-test.conclusion == 'failure' }}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
PR makes the following changes.
 - Fix the QIT API and Woo E2E tests (by updating the `run:api` command to `run:woo-api` and `run:e2e` command to `run:woo-e2e` )
 - Adds new commands to run PHPCompat and Malware tests
 - Updates some actions.
 
 Closes #236   

### Steps to test the changes in this Pull Request:
Try adding the following labels to this PR to ensure tests run:

- `needs: qit api test`
- `needs: qit e2e test`
- `needs: qit phpcompat test`
- `needs: qit malware test`


### Changelog entry
> Dev - Fix QIT E2E tests and add support for a few new test types.