### PR TITLE
Fix E2E tests for WooCommerce 9.2

### DIFF
--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -100,11 +100,13 @@ export async function editPayfastSetting( {page, settings} ) {
 		}
 	}
 
-	const waitForURLPromise = page.waitForURL(
-		'**/wp-admin/admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payfast' );
 	const submitButtonLocator = await page.locator( 'text=Save changes' );
-	await submitButtonLocator.click();
-	await waitForURLPromise;
+	if ( submitButtonLocator.isEnabled() ) {
+		const waitForURLPromise = page.waitForURL(
+			'**/wp-admin/admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payfast' );
+		await submitButtonLocator.click();
+		await waitForURLPromise;
+	}
 }
 
 /**
@@ -225,7 +227,7 @@ export async function goToOrderEditPage( {page, orderId} ){
 export async function blockFillBillingDetails(page, customerDetails) {
 	const card = await page.locator('.wc-block-components-address-card');
 	if (await card.isVisible()) {
-		await card.locator('a.wc-block-components-address-card__edit').click();
+		await card.locator('.wc-block-components-address-card__edit').click();
 	}
 
 	await page.getByLabel( 'First name' ).fill( customerDetails.firstname );

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -101,7 +101,7 @@ export async function editPayfastSetting( {page, settings} ) {
 	}
 
 	const submitButtonLocator = await page.locator( 'text=Save changes' );
-	if ( submitButtonLocator.isEnabled() ) {
+	if ( await submitButtonLocator.isEnabled() ) {
 		const waitForURLPromise = page.waitForURL(
 			'**/wp-admin/admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payfast' );
 		await submitButtonLocator.click();


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
PR updates E2E tests to accommodate the latest changes in the block checkout country/state dropdown and save settings button.

### Steps to test the changes in this Pull Request:
Make sure E2E tests are passing in GH action or locally.

### Changelog entry
> Dev - Update E2E tests to accommodate the changes in WooCommerce 9.2.