### PR TITLE
Add  credentials validation and required field notice for Payfast in sandbox environment.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -196,7 +196,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		add_filter( 'nocache_headers', array( $this, 'no_store_cache_headers' ) );
 
 		// Validate the gateway credentials.
-		add_filter( 'update_option_woocommerce_payfast_settings', array( $this, 'validate_payfast_credentials' ) , 10, 2 );
+		add_filter( 'update_option_woocommerce_payfast_settings', array( $this, 'validate_payfast_credentials' ), 10, 2 );
 	}
 
 	/**
@@ -1880,13 +1880,16 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 
 		// Check Payfast server response if the response code is not 200 then show an error message.
 		if ( 200 !== wp_remote_retrieve_response_code( $results ) ) {
-			add_action( 'admin_notices', function () {
-				?>
-				<div class="notice notice-error is-dismissible">
-					<p><?php esc_html_e( 'Invalid Payfast credentials. Please verify and enter the correct details.', 'woocommerce-gateway-payfast' ); ?></p>
-				</div>
-				<?php
-			});
+			add_action(
+				'admin_notices',
+				function () {
+					?>
+					<div class="notice notice-error is-dismissible">
+						<p><?php esc_html_e( 'Invalid Payfast credentials. Please verify and enter the correct details.', 'woocommerce-gateway-payfast' ); ?></p>
+					</div>
+					<?php
+				}
+			);
 		}
 	}
 }

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -74,7 +74,7 @@ module.exports = async ( config ) => {
 			await usernameLocator.fill( admin.username );
 			const passwordLocator = await adminPage.locator( 'input[name="pwd"]' );
 			await passwordLocator.fill( admin.password );
-			const submitButtonLocator = await adminPage.locator( 'text=Log In' );
+			const submitButtonLocator = await adminPage.locator( '#wp-submit' );
 			await submitButtonLocator.click();
 			await waitForNavigationPromise;
 
@@ -120,7 +120,7 @@ module.exports = async ( config ) => {
 			await usernameLocator.fill( admin.username );
 			const passwordLocator = await customerPage.locator( 'input[name="pwd"]' );
 			await passwordLocator.fill( admin.password );
-			const submitButtonLocator = await customerPage.locator( 'text=Log In' );
+			const submitButtonLocator = await customerPage.locator( '#wp-submit' );
 			await submitButtonLocator.click();
 			await waitForNavigationPromise;
 

--- a/tests/e2e/specs/admin/edit-settings.test.js
+++ b/tests/e2e/specs/admin/edit-settings.test.js
@@ -76,6 +76,59 @@ test.describe( 'Verify payfast setting - @foundational', async () => {
 		} );
 	} );
 
+	test( 'Edit Setting: Verify required notice for the credentials', async () => {
+		await gotoPayfastSettingPage( {page: adminPage} );
+		await editPayfastSetting( {
+			page: adminPage,
+			settings: {
+				merchant_id: '',
+				merchant_key: '',
+				passphrase: '',
+			}
+		} );
+
+		await gotoPayfastSettingPage( {page: adminPage} );
+		await expect( await adminPage.locator( '.notice.notice-error' ).last() ).toHaveText( /You forgot to fill your merchant ID/ );
+		await expect( await adminPage.locator( '.notice.notice-error' ).last() ).toHaveText( /You forgot to fill your merchant key/ );
+		await expect( await adminPage.locator( '.notice.notice-error' ).last() ).toHaveText( /Payfast requires a passphrase to work/ );
+	} );
+
+
+	test( 'Edit Setting: Verify credentials and show notice for invalid credentials', async () => {
+		await gotoPayfastSettingPage( {page: adminPage} );
+		await editPayfastSetting( {
+			page: adminPage,
+			settings: {
+				merchant_id: '1',
+				merchant_key: '1',
+				passphrase: '1',
+			}
+		} );
+
+		await expect( await adminPage.locator( '.notice.notice-error' ).last() ).toHaveText( /Invalid Payfast credentials/ );
+	} );
+
+	test( 'Edit Setting: Verify Merchant ID, Merchant Key, and Passphrase', async () => {
+		await gotoPayfastSettingPage( {page: adminPage} );
+		await editPayfastSetting( {
+			page: adminPage,
+			settings: {
+				merchant_id: payfastSandboxCredentials.merchantId,
+				merchant_key: payfastSandboxCredentials.merchantKey,
+				passphrase: payfastSandboxCredentials.passPharse,
+			}
+		} );
+
+		const merchantIdSettingLocator = await adminPage.getByLabel( 'Merchant ID', {exact: true} );
+		await expect( await merchantIdSettingLocator.inputValue() ).toEqual( payfastSandboxCredentials.merchantId );
+
+		const merchantKeySettingLocator = await adminPage.getByLabel( 'Merchant Key', {exact: true} );
+		await expect( await merchantKeySettingLocator.inputValue() ).toEqual( payfastSandboxCredentials.merchantKey );
+
+		const passphraseSettingLocator = await adminPage.getByLabel( 'Passphrase', {exact: true} );
+		await expect( await passphraseSettingLocator.inputValue() ).toEqual( payfastSandboxCredentials.passPharse );
+	} );
+
 	test( 'Checkout Block: Verify method title & description', async () => {
 		await addProductToCart( {page: checkoutBlockPage, productUrl: '/product/simple-product/'} );
 		await checkoutBlockPage.goto( '/checkout/' , { waitUntil: 'networkidle' });
@@ -99,27 +152,6 @@ test.describe( 'Verify payfast setting - @foundational', async () => {
 		await paymentMethodLocator.click();
 		await expect( await checkoutPage.locator( '.payment_box.payment_method_payfast' ) )
 			.toHaveText( /Pay with payfast/ );
-	} );
-
-	test( 'Edit Setting: Verify Merchant ID, Merchant Key, and Passphrase', async () => {
-		await gotoPayfastSettingPage( {page: adminPage} );
-		await editPayfastSetting( {
-			page: adminPage,
-			settings: {
-				merchant_id: payfastSandboxCredentials.merchantId,
-				merchant_key: payfastSandboxCredentials.merchantKey,
-				passphrase: payfastSandboxCredentials.passPharse,
-			}
-		} );
-
-		const merchantIdSettingLocator = await adminPage.getByLabel( 'Merchant ID', {exact: true} );
-		await expect( await merchantIdSettingLocator.inputValue() ).toEqual( payfastSandboxCredentials.merchantId );
-
-		const merchantKeySettingLocator = await adminPage.getByLabel( 'Merchant Key', {exact: true} );
-		await expect( await merchantKeySettingLocator.inputValue() ).toEqual( payfastSandboxCredentials.merchantKey );
-
-		const passphraseSettingLocator = await adminPage.getByLabel( 'Passphrase', {exact: true} );
-		await expect( await passphraseSettingLocator.inputValue() ).toEqual( payfastSandboxCredentials.passPharse );
 	} );
 
 	test( 'Edit Setting - Send Debug Emails - Verify when setting disabled', async () => {

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -29,7 +29,7 @@ export async function changeCurrency( {page, currency} ) {
  * @return {Promise<void>}
  */
 export async function gotoPayfastSettingPage( {page} ) {
-	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payfast' );
+	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payfast', {waitUntil: 'networkidle'} );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR adds credentials validation in the Payfast payment settings when the settings are saved and displays a corresponding notice. It also makes changes to show a required credentials field notice when the credentials are blank, and it prevents Payfast from appearing on the front-end checkout page. Previously, this required notice was only implemented for the production environment. This PR ensures it works for the sandbox environment as well.

Closes #216 

### Steps to test the changes in this Pull Request:
1. Remove all Payfast credentials from the settings and save the settings.
1. Verify that a notice with the required fields error is visible.
1. Try saving invalid credentials and verify that the merchant is prompted with an invalid credentials error.

### Changelog entry
> Add - Credentials validation and required field notice for PayFast in the sandbox environment.