### PR TITLE
Disable Warnings from WordPress Plugin Check Action

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -39,5 +39,7 @@ jobs:
           build
           assets
 
+        ignore-warnings: true
+
         ignore-codes: |
           plugin_header_no_license


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Steps to test the changes in this Pull Request:

Verify that warnings are no longer flagged in the action output.

### Changelog entry

>  Dev - Disabled warning checks from WordPress Plugin Check Action.