### PR TITLE
Update all actions we use in our workflows to pull from specific pinned commits

### DIFF
--- a/.github/workflows/backlog-automation-issues.yml
+++ b/.github/workflows/backlog-automation-issues.yml
@@ -11,7 +11,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/woocommerce/projects/73
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.nvmrc'
 
       - name: Node cache
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             node_modules
@@ -71,7 +71,7 @@ jobs:
         if: |
           always() &&
           steps.payfast_e2e_tests.conclusion == 'success'
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         continue-on-error: true
         with:
           script: |
@@ -91,7 +91,7 @@ jobs:
         if: |
           always() &&
           steps.payfast_e2e_tests.conclusion == 'failure'
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         continue-on-error: true
         with:
           script: |
@@ -111,7 +111,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: npm run test:e2e
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -9,11 +9,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Cache node_modules
               id: cache-node-modules
-              uses: actions/cache@v4
+              uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
               env:
                   cache-name: cache-node-modules
               with:
@@ -21,13 +21,13 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Setup node version and npm cache
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
               with:
                   node-version-file: '.nvmrc'
                   cache: 'npm'
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
               with:
                 php-version: '7.4'
                 tools: composer:v2
@@ -40,7 +40,7 @@ jobs:
               run: npm run build && rm -rf ./woocommerce-gateway-payfast && unzip woocommerce-gateway-payfast.zip -d ./woocommerce-gateway-payfast
 
             - name: Use the Upload Artifact GitHub Action
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
               with:
                   name: woocommerce-gateway-payfast
                   path: woocommerce-gateway-payfast/

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Sync repository labels
     steps:
-      - uses: woocommerce/woo-std-labels@v1
+      - uses: woocommerce/woo-std-labels@91ab3bca9daf544f250eafbbc2b66e039cc0c790 # v1.2.2
         with:
           labels-path: /home/runner/work/_actions/woocommerce/woo-std-labels/v1/labels.json
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 🚚 Get latest code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: ⚙️ Install Utilities
       run: sudo apt-get update && sudo apt-get install -y lftp --allow-downgrades;
-      
 
     - name: 🔑 Prepare SSH key and known hosts
       run:  mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts && ssh-keyscan sftp.pressable.com >> ~/.ssh/known_hosts
-        
+
     - name: 📂 Sync files
       run: lftp -p22 sftp://${{ secrets.SFTP_USER }}:${{ secrets.SFTP_PASSWORD }}@sftp.pressable.com -e "mirror -v -R --exclude .git/ --exclude docker/ --exclude .github/ ./ ./wp-content/plugins/woocommerce-payfast-gateway/"

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Setup proper PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
           php-version: 7.4
           tools: composer
@@ -25,7 +25,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Setup proper PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
           php-version: 7.4
           tools: composer
@@ -25,7 +25,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: |
             **/*.php

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Run plugin check
-      uses: wordpress/plugin-check-action@v1
+      uses: wordpress/plugin-check-action@70f38272b2beee386e973f319591baa2fc7dff16 # v1.1.2
       with:
         exclude-checks: |
           plugin_readme
@@ -29,7 +29,7 @@ jobs:
           performant_wp_query_params
           enqueued_scripts_in_footer
           plugin_header_text_domain
-        
+
         exclude-directories: |
           .github
           node_modules

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # v4.2.0
         with:
           name: woocommerce-gateway-payfast
 
@@ -52,7 +52,7 @@ jobs:
         run: mv woocommerce-gateway-payfast woocommerce-payfast-gateway && zip -r woocommerce-payfast-gateway.zip woocommerce-payfast-gateway
 
       - name: Set PHP version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
           php-version: 7.4
           tools: composer:v2
@@ -69,7 +69,7 @@ jobs:
         id: run-activation-test
         run: ./vendor/bin/qit run:activation woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > activation-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         if: ${{ failure() && steps.run-activation-test.conclusion == 'failure' }}
         with:
           header: QIT activation result
@@ -81,7 +81,7 @@ jobs:
         id: run-api-test
         run: ./vendor/bin/qit run:woo-api woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > api-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         if: ${{ failure() && steps.run-api-test.conclusion == 'failure' }}
         with:
           header: QIT API result
@@ -93,7 +93,7 @@ jobs:
         id: run-e2e-test
         run: ./vendor/bin/qit run:woo-e2e woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > e2e-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         if: ${{ failure() && steps.run-e2e-test.conclusion == 'failure' }}
         with:
           header: QIT E2E result
@@ -104,8 +104,8 @@ jobs:
         if: "${{ inputs.tests == 'phpstan' || contains(github.event.pull_request.labels.*.name, 'needs: qit phpstan test') && ( success() || failure() ) }}"
         id: run-phpstan-test
         run: ./vendor/bin/qit run:phpstan woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > phpstan-result.txt
-        
-      - uses: marocchino/sticky-pull-request-comment@v2
+
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
         with:
           header: QIT PHPStan result
@@ -117,7 +117,7 @@ jobs:
         id: run-phpcompat-test
         run: ./vendor/bin/qit run:phpcompatibility woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > phpcompat-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         if: ${{ failure() && steps.run-phpcompat-test.conclusion == 'failure' }}
         with:
           header: QIT PHPCompat result
@@ -129,7 +129,7 @@ jobs:
         id: run-security-test
         run: ./vendor/bin/qit run:security woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > security-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         if: ${{ failure() && steps.run-security-test.conclusion == 'failure' }}
         with:
           header: QIT security result
@@ -141,7 +141,7 @@ jobs:
         id: run-malware-test
         run: ./vendor/bin/qit run:malware woocommerce-payfast-gateway --zip=woocommerce-payfast-gateway.zip --wait > malware-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         if: ${{ failure() && steps.run-malware-test.conclusion == 'failure' }}
         with:
           header: QIT malware result


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

In order to help protect against compromised actions, instead of including actions based on their major version (like v4), this PR switches all the actions we use to pull based on the commit hash from the latest release.

While this does impact maintenance a bit going forward, it ensures that we we're always using actions that we (hopefully) trust and if an action gets compromised (which [happens](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/)) we don't have to worry that we're using a compromised action. This also goes along with what [GitHub suggests](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

### Steps to test the changes in this Pull Request:

Ensure all our workflows still run as expected

### Changelog entry

> Dev - Update all third-party actions our workflows rely on to use versions based on specific commit hashes.