### PR TITLE
Compatibility testing with WordPress 6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Give customers more flexibility and increase your bottom line with Payfast — o
 
 ## Dependencies
 
-- Requires at least: 6.4
-- Tested up to: 6.6
+- Requires at least: 6.6
+- Tested up to: 6.8
 - Requires PHP: 7.4
 
 ## Features

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Payfast Gateway ===
 Contributors: woocommerce, automattic
 Tags: credit card, payfast, payment request, woocommerce, automattic
-Requires at least: 6.5
-Tested up to: 6.7
+Requires at least: 6.6
+Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 1.7.0
 License: GPLv3

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Version: 1.7.0
  * Requires at least: 6.6
- * Tested up to: 6.7
+ * Tested up to: 6.8
  * WC requires at least: 9.6
  * WC tested up to: 9.8
  * Requires PHP: 7.4


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

 - Bump WordPress "tested up to" version 6.8.
 - Bump WordPress minimum supported version to 6.6.



Closes https://github.com/woocommerce/woocommerce-gateway-payfast/issues/292


### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.8.
> Dev - Bump WordPress minimum supported version to 6.6.


