### PR TITLE
Avoid undefined variable warning.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1811,7 +1811,8 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			return $currency;
 		}
 
-		$user_id = get_current_user_id();
+		$user_id       = get_current_user_id();
+		$currency_code = null; // Initialize to avoid undefined variable notice.
 
 		// Check if the currency is set in the URL.
 		if ( isset( $_GET['currency'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Avoids the warning `PHP Warning: Undefined variable $currency_code in /srv/htdocs/wp-content/plugins/woocommerce-payfast-gateway/includes/class-wc-gateway-payfast.php on line 1829` by defining the variable outside of conditionals within the method.

Closes #271.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Configure the store to a locale supported by WooPayments
2. Configure the store to sell in South African Rand (ZAR)
3. Activate Payfast
4. Create a simple product
5. Activate WooPayments in test mode
6. During the WooPayments onboarding, on trunk the warning above will be thrown. On this branch it should not be.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - PHP warning for undefined variable when running alongside WooPayments.