### PR TITLE
Add WordPres Playground Blueprint for extension.

### DIFF
--- a/wordpress_org_assets/blueprint-payfast-takeover.php.txt
+++ b/wordpress_org_assets/blueprint-payfast-takeover.php.txt
@@ -1,0 +1,66 @@
+<?php
+/**
+ * MU Plugin for the WordPress Playground.
+ *
+ * When importing this in to the blueprint.json file, run the code through
+ * https://www.freeformatter.com/json-escape.html to escape it correctly.
+ */
+
+
+namespace WC_Gateway_Payfast\WP_Playground;
+
+add_action( 'init', __NAMESPACE__ . '\\woocommerce_payfast_init' );
+
+/**
+ * Initialize Payfast gateway for WordPress Playground.
+ *
+ * Replaces the default Payfast receipt page with a custom message
+ * explaining the limitations of WordPress Playground regarding payment
+ * redirection.
+ */
+function woocommerce_payfast_init() {
+	$payfast = get_payfast_gateway_instance();
+
+	if ( ! $payfast ) {
+		return;
+	}
+
+	remove_action( 'woocommerce_receipt_payfast', array( $payfast, 'receipt_page' ) );
+	add_action( 'woocommerce_receipt_payfast', __NAMESPACE__ . '\\receipt_page' );
+}
+
+/**
+ * Get the Payfast gateway instance.
+ *
+ * @return WC_Payment_Gateway|false The Payfast gateway instance or false if not found.
+ */
+function get_payfast_gateway_instance() {
+	$gatways = WC()->payment_gateways->get_available_payment_gateways();
+
+	if ( isset( $gatways['payfast'] ) ) {
+		return $gatways['payfast'];
+	}
+
+	return false;
+}
+
+/**
+ * Custom receipt page for Payfast in WordPress Playground.
+ *
+ * Replaces the default redirect with an explanation for users explaining
+ * that the WordPress Playground does not support payment redirection
+ * for security reasons.
+ *
+ * @param \WC_Order $order The order object.
+ */
+function receipt_page( $order ) {
+	?>
+	<div>
+		<h2><?php esc_html_e( 'Payfast payment redirection', 'woocommerce-gateway-payfast' ); ?></h2>
+
+		<p><?php esc_html_e( 'WordPress Playground does not support Payfast payment redirection for security reasons.', 'woocommerce-gateway-payfast' ); ?></p>
+		<p><?php esc_html_e( 'At this point in the checkout process, you would be redirected to the Payfast payment page to complete your transaction.', 'woocommerce-gateway-payfast' ); ?></p>
+		<p><?php esc_html_e( 'Please use a local WordPress installation or a live server to test the Payfast payment gateway checkout process.', 'woocommerce-gateway-payfast' ); ?></p>
+	</div>
+	<?php
+}

--- a/wordpress_org_assets/blueprint.json
+++ b/wordpress_org_assets/blueprint.json
@@ -18,6 +18,11 @@
 			"data": "<?php add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );"
 		},
 		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/woocommerce-payfast-playground.php",
+			"data": "<?php\r\n\r\nnamespace WC_Gateway_Payfast\\WP_Playground;\r\n\r\nadd_action( 'init', __NAMESPACE__ . '\\\\woocommerce_payfast_init' );\r\n\r\nfunction woocommerce_payfast_init() {\r\n\t$payfast = get_payfast_gateway_instance();\r\n\r\n\tif ( ! $payfast ) {\r\n\t\treturn;\r\n\t}\r\n\r\n\tremove_action( 'woocommerce_receipt_payfast', array( $payfast, 'receipt_page' ) );\r\n\tadd_action( 'woocommerce_receipt_payfast', __NAMESPACE__ . '\\\\receipt_page' );\r\n}\r\n\r\nfunction get_payfast_gateway_instance() {\r\n\t$gatways = WC()->payment_gateways->get_available_payment_gateways();\r\n\r\n\tif ( isset( $gatways['payfast'] ) ) {\r\n\t\treturn $gatways['payfast'];\r\n\t}\r\n\r\n\treturn false;\r\n}\r\n\r\nfunction receipt_page() {\r\n\t?>\r\n\t<div>\r\n\t\t<h2><?php esc_html_e( 'Payfast payment redirection', 'woocommerce-gateway-payfast' ); ?><\/h2>\r\n\r\n\t\t<p><?php esc_html_e( 'WordPress Playground does not support Payfast payment redirection for security reasons.', 'woocommerce-gateway-payfast' ); ?><\/p>\r\n\t\t<p><?php esc_html_e( 'At this point in the checkout process, you would be redirected to the Payfast payment page to complete your transaction.', 'woocommerce-gateway-payfast' ); ?><\/p>\r\n\t\t<p><?php esc_html_e( 'Please use a local WordPress installation or a live server to test the Payfast payment gateway checkout process.', 'woocommerce-gateway-payfast' ); ?><\/p>\r\n\t<\/div>\r\n\t<?php\r\n}\r\n"
+		},
+		{
 			"step": "wp-cli",
 			"command": "wp wc tool run install_pages --user=1"
 		},

--- a/wordpress_org_assets/blueprint.json
+++ b/wordpress_org_assets/blueprint.json
@@ -1,0 +1,51 @@
+{
+	"landingPage": "/wp-admin/admin.php?page=wc-settings&tab=checkout&section=payfast",
+	"login": true,
+	"plugins": [
+		"woocommerce",
+		"woocommerce-payfast-gateway"
+	],
+	"features": {
+		"networking": true
+	},
+	"phpExtensionBundles": [
+		"kitchen-sink"
+	],
+	"steps": [
+		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/skip-woo-activation.php",
+			"data": "<?php add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp wc tool run install_pages --user=1"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp option update woocommerce_onboarding_profile '{\"completed\":true,\"skipped\":false}' --format=json"
+		},
+		{
+			"step": "importWxr",
+			"file": {
+			"resource": "url",
+			"url": "https://raw.githubusercontent.com/woocommerce/woocommerce/d1be68b88c93caca359e93ff927017a2fafec1fc/plugins/woocommerce/sample-data/sample_products.xml"
+			}
+		},
+		{
+			"step": "setSiteOptions",
+			"options": {
+			"woocommerce_newly_installed": "no",
+			"woocommerce_store_address": "90 Plein Street",
+			"woocommerce_store_city": "Cape Town",
+			"woocommerce_default_country": "ZA:WC",
+			"woocommerce_store_postcode": "8000",
+			"woocommerce_allowed_countries": "all",
+			"woocommerce_ship_to_countries": "all",
+			"woocommerce_currency": "ZAR",
+			"woocommerce_coming_soon": "no",
+			"woocommerce_allow_tracking": "no"
+			}
+		}
+	]
+}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Adds a blueprint file for running the extension in the WordPress Playground.  [Demo link](https://playground.wordpress.net/#{%22landingPage%22:%22/wp-admin/admin.php?page=wc-settings&tab=checkout&section=payfast%22,%22login%22:true,%22plugins%22:[%22woocommerce%22,%22woocommerce-payfast-gateway%22],%22features%22:{%22networking%22:true},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22steps%22:[{%22step%22:%22writeFile%22,%22path%22:%22/wordpress/wp-content/mu-plugins/skip-woo-activation.php%22,%22data%22:%22%3C?php%20add_filter(%20'woocommerce_enable_setup_wizard',%20'__return_false'%20);%22},{%22step%22:%22writeFile%22,%22path%22:%22/wordpress/wp-content/mu-plugins/woocommerce-payfast-playground.php%22,%22data%22:%22%3C?php\r\n\r\nnamespace%20WC_Gateway_Payfast\\WP_Playground;\r\n\r\nadd_action(%20'init',%20__NAMESPACE__%20.%20'\\\\woocommerce_payfast_init'%20);\r\n\r\nfunction%20woocommerce_payfast_init()%20{\r\n\t$payfast%20=%20get_payfast_gateway_instance();\r\n\r\n\tif%20(%20!%20$payfast%20)%20{\r\n\t\treturn;\r\n\t}\r\n\r\n\tremove_action(%20'woocommerce_receipt_payfast',%20array(%20$payfast,%20'receipt_page'%20)%20);\r\n\tadd_action(%20'woocommerce_receipt_payfast',%20__NAMESPACE__%20.%20'\\\\receipt_page'%20);\r\n}\r\n\r\nfunction%20get_payfast_gateway_instance()%20{\r\n\t$gatways%20=%20WC()-%3Epayment_gateways-%3Eget_available_payment_gateways();\r\n\r\n\tif%20(%20isset(%20$gatways['payfast']%20)%20)%20{\r\n\t\treturn%20$gatways['payfast'];\r\n\t}\r\n\r\n\treturn%20false;\r\n}\r\n\r\nfunction%20receipt_page()%20{\r\n\t?%3E\r\n\t%3Cdiv%3E\r\n\t\t%3Ch2%3E%3C?php%20esc_html_e(%20'Payfast%20payment%20redirection',%20'woocommerce-gateway-payfast'%20);%20?%3E%3C/h2%3E\r\n\r\n\t\t%3Cp%3E%3C?php%20esc_html_e(%20'WordPress%20Playground%20does%20not%20support%20Payfast%20payment%20redirection%20for%20security%20reasons.',%20'woocommerce-gateway-payfast'%20);%20?%3E%3C/p%3E\r\n\t\t%3Cp%3E%3C?php%20esc_html_e(%20'At%20this%20point%20in%20the%20checkout%20process,%20you%20would%20be%20redirected%20to%20the%20Payfast%20payment%20page%20to%20complete%20your%20transaction.',%20'woocommerce-gateway-payfast'%20);%20?%3E%3C/p%3E\r\n\t\t%3Cp%3E%3C?php%20esc_html_e(%20'Please%20use%20a%20local%20WordPress%20installation%20or%20a%20live%20server%20to%20test%20the%20Payfast%20payment%20gateway%20checkout%20process.',%20'woocommerce-gateway-payfast'%20);%20?%3E%3C/p%3E\r\n\t%3C/div%3E\r\n\t%3C?php\r\n}\r\n%22},{%22step%22:%22wp-cli%22,%22command%22:%22wp%20wc%20tool%20run%20install_pages%20--user=1%22},{%22step%22:%22wp-cli%22,%22command%22:%22wp%20option%20update%20woocommerce_onboarding_profile%20'{\%22completed\%22:true,\%22skipped\%22:false}'%20--format=json%22},{%22step%22:%22importWxr%22,%22file%22:{%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/woocommerce/woocommerce/d1be68b88c93caca359e93ff927017a2fafec1fc/plugins/woocommerce/sample-data/sample_products.xml%22}},{%22step%22:%22setSiteOptions%22,%22options%22:{%22woocommerce_newly_installed%22:%22no%22,%22woocommerce_store_address%22:%2290%20Plein%20Street%22,%22woocommerce_store_city%22:%22Cape%20Town%22,%22woocommerce_default_country%22:%22ZA:WC%22,%22woocommerce_store_postcode%22:%228000%22,%22woocommerce_allowed_countries%22:%22all%22,%22woocommerce_ship_to_countries%22:%22all%22,%22woocommerce_currency%22:%22ZAR%22,%22woocommerce_coming_soon%22:%22no%22,%22woocommerce_allow_tracking%22:%22no%22}}]}).

Steps:

1. Installs WooCommerce and WooCommerce Payfast Gateway
2. Creates an mu-plugin to bypass the WooCommerce onboarding redirect.
3. Creates an mu-plugin to prevent redirection to the gateway (due to Playground limitations as it runs in an iframe)
4. Installs the WooCommerce pages (cart, checkout, etc) via WP-CLI
5. Imports the sample products from the WooCommerce plugin sample data
6. Sets some sensible default options
   * Address (I used the address of the South African parliament)
   * Currency: ZAR
   * Disables tracking (to avoid network requests in playground)
   * Turns off the store coming soon option
7. Lands on the payfast settings page, `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=payfast`

The copy used to replace the redirect to Payfast explains why but will almost certainly need a copy edit:

> Payfast payment redirection
>
> WordPress Playground does not support Payfast payment redirection for security reasons.
>
> At this point in the checkout process, you would be redirected to the Payfast payment page to complete your transaction.
>
> Please use a local WordPress installation or a live server to test the Payfast payment gateway checkout process.

At the moment, I've hidden the mu-plugin for the receipt take over page as a text file in the wordpress.org assets directory. The intention is that this will be moved prior to releasing this code.

My questions are:

a) where should it be placed
b) should we included it in the plugin's default execution and no-op the file if it's not a playground instance, or, write an mu-plugin that requires the file via a blueprint step?

Closes PAYFAST-23.

### Steps to test the changes in this Pull Request:

1. Click the demo link above
2. Ensure that the WooCommerce onboarding wizard does not load
3. Ensure that the landing page is the Payfast settings page
4. Enable the gateway and add some sandbox credentials 
5. Go to the store
6. Select a product to purchase, add it to the cart
7. Proceed through the cart to the checkout page
8. Ensure the payfast payment option is visible
9. Complete the purchase
10. Ensure the browser does not attempt to redirect to the payfast site
11. Ensure the message above displays
12. Return to the dashboard
13. Ensure that the order was stored and is showing pending payment (as the payment didn't complete)

> [!Warning]
>
> Remember that this repository is public and to avoid posting any credentials in screen casts or screenshots taken during the debugging process.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - WordPress Playground instance