### PR TITLE
Compatibility testing with WC 10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Give customers more flexibility and increase your bottom line with Payfast — o
 
 ## Dependencies
 
-- Requires at least: 6.6
+- Requires at least: 6.7
 - Tested up to: 6.8
 - Requires PHP: 7.4
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Payfast Gateway ===
 Contributors: woocommerce, automattic
 Tags: credit card, payfast, payment request, woocommerce, automattic
-Requires at least: 6.6
+Requires at least: 6.7
 Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 1.7.2

--- a/tests/e2e/specs/admin/edit-settings.test.js
+++ b/tests/e2e/specs/admin/edit-settings.test.js
@@ -77,7 +77,6 @@ test.describe( 'Verify payfast setting - @foundational', async () => {
 	} );
 
 	test( 'Edit Setting: Verify required notice for the credentials', async () => {
-		await gotoPayfastSettingPage( {page: adminPage} );
 		await editPayfastSetting( {
 			page: adminPage,
 			settings: {
@@ -87,10 +86,11 @@ test.describe( 'Verify payfast setting - @foundational', async () => {
 			}
 		} );
 
+		await adminPage.waitForTimeout( 1500 );
 		await gotoPayfastSettingPage( {page: adminPage} );
-		await expect( await adminPage.locator( '.notice.notice-error' ).last() ).toHaveText( /You forgot to fill your merchant ID/ );
-		await expect( await adminPage.locator( '.notice.notice-error' ).last() ).toHaveText( /You forgot to fill your merchant key/ );
-		await expect( await adminPage.locator( '.notice.notice-error' ).last() ).toHaveText( /Payfast requires a passphrase to work/ );
+		await expect( await adminPage.locator( '.notice.notice-error', {hasText: /You forgot to fill your merchant ID/} ).last() ).toBeVisible();
+		await expect( await adminPage.locator( '.notice.notice-error', {hasText: /You forgot to fill your merchant key/} ).last() ).toBeVisible();
+		await expect( await adminPage.locator( '.notice.notice-error', {hasText: /Payfast requires a passphrase to work/} ).last() ).toBeVisible();
 	} );
 
 

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -7,10 +7,10 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Version: 1.7.2
- * Requires at least: 6.6
+ * Requires at least: 6.7
  * Tested up to: 6.8
- * WC requires at least: 9.8
- * WC tested up to: 10.0
+ * WC requires at least: 9.9
+ * WC tested up to: 10.1
  * Requires PHP: 7.4
  * PHP tested up to: 8.3
  *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:

- Bump WooCommerce "tested up to" version 10.1
- Bump WooCommerce minimum supported version to 9.9


Closes https://linear.app/a8c/issue/PAYFAST-29/compatibility-testing-with-woo-101-rc1 

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR 
2. All tests should be passed. 

### Changelog entry

> Dev - Bump WooCommerce "tested up to" version 10.1.
> Dev - Bump WooCommerce minimum supported version to 9.9.






