### PR TITLE
Prevent cancelling tokens on ITN replays.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -707,14 +707,29 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 				$subscription = wcs_get_subscription( $order_id );
 				if ( ! empty( $subscription ) && ! empty( $token ) ) {
 					$old_token = $this->_get_subscription_token( $subscription );
-					// Cancel old subscription token of subscription if we have it.
-					if ( ! empty( $old_token ) ) {
+
+					/*
+					 * Cancel old subscription token.
+					 *
+					 * Cancels an old subscription token if it is defined and differs from
+					 * the new token. The check for the same token is to account for replayed
+					 * ITN requests as a result of an HTTP timeout or network issues returning
+					 * the success response to the Payfast gateway.
+					 */
+					if (
+						! empty( $old_token )
+						&& $old_token !== $token
+					) {
 						$this->cancel_subscription_listener( $subscription );
 					}
 
-					// Set new subscription token on subscription.
-					$this->_set_subscription_token( $token, $subscription );
-					$this->log( 'Payfast token updated on Subcription: ' . $order_id );
+					// Set new subscription token on subscription if not an ITN replay.
+					if ( $old_token !== $token ) {
+						$this->_set_subscription_token( $token, $subscription );
+						$this->log( 'Payfast token updated on Subscription: ' . $order_id );
+					} else {
+						$this->log( 'Possible ITN replay detected for Payfast token update on Subscription: ' . $order_id );
+					}
 				}
 			}
 			return;


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Detects a possible ITN request replay when updating a subscription token. If the new and old token match, the token isn't cancelled as this will result in storing a token that is no longer valid.

Replays can either triggered manually or due to network issues.

Closes https://linear.app/a8c/issue/PAYFAST-33/double-itn-request-might-cancel-valid-token

### Steps to test the changes in this Pull Request:

I was unable to reproduce the issue described in the bug, this is some defensive coding.

1. Create a simple subscription product
2. Order the product
3. In the database, look for the meta data item `_payfast_subscription_token` stored against the new subscription.
4. Take note of the value in the meta data item.
5. As the purchaser, visit My Account > My subscription/s
6. Click the link to the new subscription (this won't be required if you only have one subscription)
7. Click Change Payment
8. Proceed through the payfast flow until you return to the store
9. In the database, refresh the table to ensure the `_payfast_subscription_token` meta data has updated
10. Visit the Payfast sandbox tokenization screen, https://sandbox.payfast.co.za/tokenization
11. Ensure the initial token is listed as cancelled.
12. Visit the Payfast sandbox ITN screen, https://sandbox.payfast.co.za/itn
13. Reply the most recent transaction (select the three dots and click Re-send ITN)
14. Reutnr to the tokenization screen
15. Ensure the new token has not been cancelled.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent ITN replays cancelling valid subscription tokens.