### PR TITLE
Initialize privacy exporters on `init` hook.

### DIFF
--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -34,7 +34,6 @@ function woocommerce_payfast_init() {
 	}
 
 	require_once plugin_basename( 'includes/class-wc-gateway-payfast.php' );
-	require_once plugin_basename( 'includes/class-wc-gateway-payfast-privacy.php' );
 	load_plugin_textdomain( 'woocommerce-gateway-payfast', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
 	add_filter( 'woocommerce_payment_gateways', 'woocommerce_payfast_add_gateway' );
 }
@@ -124,6 +123,19 @@ function woocommerce_payfast_declare_feature_compatibility() {
 	}
 }
 add_action( 'before_woocommerce_init', 'woocommerce_payfast_declare_feature_compatibility' );
+
+/**
+ * Initialize the privacy class.
+ *
+ * Initializes the privacy class for privacy export tools.
+ *
+ * @since x.x.x
+ * @return void
+ */
+function woocommerce_payfast_privacy_init() {
+		require_once plugin_basename( 'includes/class-wc-gateway-payfast-privacy.php' );
+}
+add_action( 'woocommerce_init', 'woocommerce_payfast_privacy_init' );
 
 /**
  * Display notice if WooCommerce is not installed.


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Relocates the initialization of the privacy export class from the `plugin_loaded` hook to the `woocommerce_init` hook, which fires on the WordPress `init` hook.

This is to prevent WordPress throwing a notice due to the early calling of `_load_textdomain_just_in_time` via the privacy constructor. 

> [!Note]
>
> The plugin uses the domain `woocommerce-gateway-payfast` while the slug on WordPress.org is `woocommerce-payfast-gateway`. For the time being this is preventing the removal of the `load_plugin_textdomain` call.
>
> In order to remove it, the domain will need to be updated to match the wp.org plugin slug. See [the i18n docs](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#:~:text=The%20text%20domain%20must%20match%20the).

Closes https://linear.app/a8c/issue/PAYFAST-38/php-notice-function-load-textdomain-just-in-time-was-called

### Steps to test the changes in this Pull Request:

1. Log in to the dashboard
2. Enable Query Monitor
3. Ensure payfast does not trigger a doing_it_wrong notice.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent notice being thrown due to the early loading of translations.