### PR TITLE
PHP 8.4 Compatibility.

### DIFF
--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -4,35 +4,53 @@ on: pull_request
 
 jobs:
   php-compatibility:
+    name: PHP compatibility
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
         with:
-          fetch-depth: 0
+          tools: cs2pr
+          install-deps: no
 
-      - name: Setup proper PHP version
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+      - name: Prepare node
+        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
         with:
-          php-version: 7.4
-          tools: composer
+          node-version-file: ".nvmrc"
+          ignore-scripts: "no"
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate --strict
+      # The use of WP-Scripts results in PHP files being generated during the npm build step.
+      # In order to ensure PHP Compatibility, the build step must be run in order to ensure all
+      # files in the production release of the plugin are compatible with the target PHP versions.
+      - name: Build production bundle
+        run: npm run build
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      # Unzip the newly created zip file to a separate directory.
+      - name: Unzip production bundle
+        run: |
+          mv woocommerce-gateway-payfast.zip ~
+          cd ~
+          mkdir prod
+          unzip woocommerce-gateway-payfast.zip -d prod
+          cd -
 
-      - name: Cache dependencies
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+      - name: Copy phpcompat sniffs to production directory
+        run: cp phpcs-compat.xml.dist ~/prod/woocommerce-gateway-payfast/phpcs-compat.xml.dist
 
-      - name: Install dependencies
-        run: composer install
+      # Installed globally to ensure dev dependencies are not included in compatibility sniffs.
+      # At the time of writing no production version of PHPCompatibility/PHP-Compatibility supports
+      # PHP 8.4 so a dev version is used in order to ensure the sniffs that have been created are
+      # included in the checks.
+      - name: Install PHP Compatibility dev-develop globally
+        run: |
+          composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require --dev phpcompatibility/php-compatibility:dev-develop#8daeec54772a592ad369be23ae02ed593c71e7f1
 
-      - name: Run PHP Compatibility
-        run: ./vendor/bin/phpcs --standard=phpcs-compat.xml.dist -p .
+      - name: Run PHPCompatibility on all files
+        run: |
+          cd ~/prod/woocommerce-gateway-payfast
+          ~/.composer/vendor/bin/phpcs . --standard=phpcs-compat.xml.dist -ps --basepath=.

--- a/phpcs-compat.xml.dist
+++ b/phpcs-compat.xml.dist
@@ -1,18 +1,65 @@
 <?xml version="1.0"?>
-<ruleset name="PHPCompatibilityWP">
-    <rule ref="PHPCompatibility"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilityWP" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
-    <!-- Files to check -->
-    <arg name="extensions" value="php"/>
-    <file>.</file>
+    <description>WordPress specific ruleset which checks for PHP cross version compatibility.</description>
+	<!-- Once PHPCompatibility/PHPCompatibilityWP supports the targeted versions of PHP, this config file can be updated accordingly. -->
 
-    <exclude-pattern>vendor/</exclude-pattern>
-    <exclude-pattern>dist/</exclude-pattern>
-    <exclude-pattern>node_modules</exclude-pattern>
-    <exclude-pattern>tests</exclude-pattern>
-    <exclude-pattern>assets</exclude-pattern>
-    <exclude-pattern>build</exclude-pattern>
-    <exclude-pattern>client</exclude-pattern>
+	<!-- Test PHP 7.4 thru 8.4 -->
+	<config name="testVersion" value="7.4-8.4"/>
+	<file>.</file>
+	<arg name="extensions" value="php,inc" />
 
-    <config name="testVersion" value="7.4-"/>
+    <rule ref="PHPCompatibility">
+        <!--
+        Contained in /wp-includes/compat.php.
+
+        History of the polyfills in WP:
+        * hash_hmac(): since WP 3.2.0.
+        * json_encode() and json_decode(): since unknown.
+        * hash_equals(): since WP 3.9.2.
+        * JSON_PRETTY_PRINT: since WP 4.1.0.
+        * json_last_error_msg(): since WP 4.4.0.
+        * JsonSerializable: since WP 4.4.0.
+        * array_replace_recursive(): since WP 4.5.3 up to 5.2.x. The polyfill was removed in WP 5.3.
+        * is_iterable(): since WP 4.9.6
+        * is_countable(): since WP 4.9.6
+        * IMAGETYPE_WEBP and IMG_WEBP: since WP 5.8.0.
+        * array_key_first(): since WP 5.9.0
+        * array_key_last(): since WP 5.9.0
+        * str_contains(): since WP 5.9.0
+        * str_starts_with(): since WP 5.9.0
+        * str_ends_with(): since WP 5.9.0
+        * array_is_list(): since WP 6.5.0
+        -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_decodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_equalsFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.json_pretty_printFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.jsonserializableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_replace_recursiveFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_countableFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.imagetype_webpFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.img_webpFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_firstFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
+
+        <!--
+        Contained in /wp-includes/spl-autoload-compat.php.
+
+        History of the polyfills in WP:
+        * spl_autoload_register(), spl_autoload_unregister() and spl_autoload_functions() were
+          introduced in WP 4.6.0 and available up to WP 5.2.x. The polyfills were removed in WP 5.3.
+        -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_registerFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_unregisterFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
+    </rule>
+
 </ruleset>

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -12,7 +12,7 @@
  * WC requires at least: 10.0
  * WC tested up to: 10.2
  * Requires PHP: 7.4
- * PHP tested up to: 8.3
+ * PHP tested up to: 8.4
  *
  * @package WooCommerce Gateway Payfast
  */


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Updates the PHP Compat workflow to do the following:

* Run the sniffs against all files in the production build
* Run a dev version of the phpcompatibility/php-compatibility package that includes the key PHP 8.4 compatibility sniffs.

Closes https://linear.app/a8c/issue/PAYFAST-45/project-ensure-php-84-compatibility

### Steps to test the changes in this Pull Request:

1. Configure a WordPress environment running on PHP 8.4
2. In wp-config.php enable WP_DEBUG and WP_DEBUG_LOG, see [debugging WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/)
3. Activate the Query Monitor plugin
4. Run through each of the [critical flows](https://github.com/woocommerce/woocommerce-gateway-payfast/wiki/Critical-Flows).
5. Monitor QM and the PHP logs for php deprecation notices and warnings. Ignore the notice for `Function _load_textdomain_just_in_time was called incorrectly`, that is resolved in https://github.com/woocommerce/woocommerce-gateway-payfast/pull/325

This run of the [E2E tests action](https://github.com/woocommerce/woocommerce-gateway-payfast/actions/runs/18454243270/job/52572857909?pr=331) ran on PHP 8.4, the associated commit has since been removed from the PRs history.

### Changelog entry

> Dev - Run PHP Compatibility sniffs against production build in GitHub action.