### PR TITLE
Compatibility testing with WordPress 6.9

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
           unzip -o woocommerce-subscriptions.zip
           cd ../../..
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ORG_DOWNLOADS }}
 
       - name: Setup WP environment
         run: npm run env:start

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Give customers more flexibility and increase your bottom line with Payfast — o
 ## Dependencies
 
 - Requires at least: 6.7
-- Tested up to: 6.8
+- Tested up to: 6.9
 - Requires PHP: 7.4
 
 ## Features

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 6.7
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 1.7.4
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: credit card, payfast, payment request, woocommerce, automattic
 Requires at least: 6.7
-Tested up to: 6.9
+Tested up to: 6.8
 Requires PHP: 7.4
 Stable tag: 1.7.4
 License: GPLv3

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com/
  * Version: 1.7.4
  * Requires at least: 6.7
- * Tested up to: 6.8
+ * Tested up to: 6.9
  * WC requires at least: 10.1
  * WC tested up to: 10.3
  * Requires PHP: 7.4


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

 - Bump WordPress "tested up to" version 6.9




Closes https://linear.app/a8c/issue/PAYFAST-50/compatibility-testing-with-wordpress-69-rc1


### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed. 
 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.9.


