### PR TITLE
Bump WooCommerce "tested up to" version 10.5

### DIFF
--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -9,8 +9,8 @@
  * Version: 1.7.4
  * Requires at least: 6.7
  * Tested up to: 6.9
- * WC requires at least: 10.2
- * WC tested up to: 10.4
+ * WC requires at least: 10.3
+ * WC tested up to: 10.5
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
  *


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://linear.app/a8c/issue/PAYFAST-54/compatibility-testing-with-woo-105-beta

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run the e2e test using GitHub action to test this PR
2. All tests should be passed.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce "tested up to" version 10.5.
> Dev - Bump WooCommerce minimum supported version to 10.3.