### PR TITLE
[Plugin Check action] Bump the Plugin Check action version to 1.1.5

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -43,3 +43,4 @@ jobs:
 
         ignore-codes: |
           plugin_header_no_license
+          PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Run plugin check
-      uses: wordpress/plugin-check-action@70f38272b2beee386e973f319591baa2fc7dff16 # v1.1.2
+      uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
       with:
         exclude-checks: |
           plugin_readme

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -41,6 +41,8 @@ jobs:
 
         ignore-warnings: true
 
+        # Ignoring this here as removal of load_plugin_textdomain requires quite some changes,
+        # involving textdomain updates and translation files. This requires a separate effort and is not part of this PR.
         ignore-codes: |
           plugin_header_no_license
           PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -5,6 +5,10 @@
  * @package WooCommerce Gateway Payfast
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Payfast Payment Gateway
  *

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -34,10 +34,19 @@ function woocommerce_payfast_init() {
 	}
 
 	require_once plugin_basename( 'includes/class-wc-gateway-payfast.php' );
-	load_plugin_textdomain( 'woocommerce-gateway-payfast', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
 	add_filter( 'woocommerce_payment_gateways', 'woocommerce_payfast_add_gateway' );
 }
 add_action( 'plugins_loaded', 'woocommerce_payfast_init', 0 );
+
+/**
+ * Load plugin text domain for translations.
+ *
+ * @since 1.0.0
+ */
+function woocommerce_payfast_load_plugin_textdomain() {
+	load_plugin_textdomain( 'woocommerce-gateway-payfast', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
+}
+add_action( 'init', 'woocommerce_payfast_load_plugin_textdomain' );
 
 /**
  * Add links to the plugin action links.

--- a/woocommerce-gateway-payfast.php
+++ b/woocommerce-gateway-payfast.php
@@ -34,19 +34,10 @@ function woocommerce_payfast_init() {
 	}
 
 	require_once plugin_basename( 'includes/class-wc-gateway-payfast.php' );
+	load_plugin_textdomain( 'woocommerce-gateway-payfast', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
 	add_filter( 'woocommerce_payment_gateways', 'woocommerce_payfast_add_gateway' );
 }
 add_action( 'plugins_loaded', 'woocommerce_payfast_init', 0 );
-
-/**
- * Load plugin text domain for translations.
- *
- * @since 1.0.0
- */
-function woocommerce_payfast_load_plugin_textdomain() {
-	load_plugin_textdomain( 'woocommerce-gateway-payfast', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
-}
-add_action( 'init', 'woocommerce_payfast_load_plugin_textdomain' );
 
 /**
  * Add links to the plugin action links.


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---
### Changes proposed in this Pull Request:
This pull request upgrades the `wordpress/plugin-check-action` from version `v1.1.2` to `v1.1.5` to fix `Error: Required file 'cli.php' doesn't exist (from runtime argument)` error.

Add ignore for the code PluginCheck.CodeAnalysis.DiscouragedFunctions.load_plugin_textdomainFound for plugin check

> [!NOTE]
> With the Plugin Check action working now, it has started reporting some errors, and they should be addressed in a follow-up PR.


### Steps to test the changes in this Pull Request:
1. Verify that plugin check action is running correctly on this PR and adding comment with reported errors.

### Changelog entry
> Dev - Bump the `plugin-check-action` GitHub Action version to v1.1.5 to fix the runner path failure.

Closes #358
Closes https://linear.app/a8c/issue/PAYFAST-66/fix-errors-reported-by-plugin-check-action