### PR TITLE
Fix Payfast rejecting relative return URLs from third-party endpoint filters.

### DIFF
--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -1931,7 +1931,10 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		if ( get_option( 'permalink_structure' ) ) {
 			$query_string = '';
 			if ( strstr( $checkout_url, '?' ) ) {
-				$query_string = '?' . wp_parse_url( $checkout_url, PHP_URL_QUERY );
+				$parsed_query = wp_parse_url( $checkout_url, PHP_URL_QUERY );
+				if ( ! empty( $parsed_query ) ) {
+					$query_string = '?' . $parsed_query;
+				}
 				$checkout_url = current( explode( '?', $checkout_url ) );
 			}
 

--- a/includes/class-wc-gateway-payfast.php
+++ b/includes/class-wc-gateway-payfast.php
@@ -426,7 +426,7 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 			// Merchant details.
 			'merchant_id'      => $this->merchant_id,
 			'merchant_key'     => $this->merchant_key,
-			'return_url'       => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->get_return_url( $order ) ) ),
+			'return_url'       => $this->get_payfast_return_url( $order ),
 			'cancel_url'       => $order->get_cancel_order_url(),
 			'notify_url'       => $this->response_url,
 
@@ -1897,6 +1897,60 @@ class WC_Gateway_PayFast extends WC_Payment_Gateway {
 		}
 
 		return $currency;
+	}
+
+	/**
+	 * Get a Payfast-safe order return URL.
+	 *
+	 * Third-party plugins can turn the order-received
+	 * URL into a relative `/order-received/{id}/` path. Payfast rejects relative
+	 * URLs, so rebuild from the checkout URL without endpoint filters.
+	 *
+	 * @since x.x.x
+	 * @param WC_Order $order Order object.
+	 * @return string Absolute checkout order-received URL.
+	 */
+	protected function get_payfast_return_url( $order ) {
+		$return_url = add_query_arg( 'utm_nooverride', '1', $this->get_return_url( $order ) );
+
+		if ( preg_match( '#^https?://#i', $return_url ) ) {
+			return esc_url_raw( $return_url );
+		}
+
+		// Avoid wc_get_endpoint_url() so endpoint filters cannot strip the checkout base.
+		$checkout_url = wc_get_checkout_url();
+		$endpoint     = get_option( 'woocommerce_checkout_order_received_endpoint', 'order-received' );
+
+		if ( WC()->query ) {
+			$query_vars = WC()->query->get_query_vars();
+			if ( ! empty( $query_vars['order-received'] ) ) {
+				$endpoint = $query_vars['order-received'];
+			}
+		}
+
+		if ( get_option( 'permalink_structure' ) ) {
+			$query_string = '';
+			if ( strstr( $checkout_url, '?' ) ) {
+				$query_string = '?' . wp_parse_url( $checkout_url, PHP_URL_QUERY );
+				$checkout_url = current( explode( '?', $checkout_url ) );
+			}
+
+			$return_url  = trailingslashit( $checkout_url );
+			$return_url .= trailingslashit( $endpoint ) . user_trailingslashit( $order->get_id() );
+			$return_url .= $query_string;
+		} else {
+			$return_url = add_query_arg( $endpoint, $order->get_id(), $checkout_url );
+		}
+
+		$return_url = add_query_arg(
+			array(
+				'key'            => $order->get_order_key(),
+				'utm_nooverride' => '1',
+			),
+			$return_url
+		);
+
+		return esc_url_raw( $return_url );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

When some third-party plugins (notably Elementor Pro with a broken/missing Purchase Summary page) filter `woocommerce_get_endpoint_url`, the order-received URL becomes a relative path like `/order-received/{id}/`. Payfast rejects that with `return_url: The return URL format is invalid`.

This PR adds `get_payfast_return_url()` so that if the return URL is not absolute, Payfast rebuilds it from the checkout URL (without going through `wc_get_endpoint_url()`, which those filters hook) and includes the order key + `utm_nooverride`.

Closes https://linear.app/a8c/issue/PAYFAST-109/payfast-gateway-generates-relative-return-urls-causing-return-url.

### Steps to test the changes in this Pull Request:

**Happy path (unchanged behavior)**
1. On a normal store (no Elementor Purchase Summary misconfiguration), place a Payfast order.
2. On the redirect form, confirm `return_url` is absolute and points at `/checkout/order-received/{id}/?...`.
3. Complete payment and confirm you land on the thank-you page.

**Regression case (relative return URL)**
1. Install Elementor Pro, create a page, set it as **Elementor → Site Settings → WooCommerce → Purchase Summary**.
2. Permanently delete that page (leave `elementor_woocommerce_purchase_summary_page_id` pointing at the deleted ID).
3. Without this fix: place a Payfast order and confirm Payfast errors with an invalid/relative `return_url`.
4. With this fix: place a Payfast order, confirm `return_url` is rebuilt to an absolute `/checkout/order-received/{id}/?key=...&utm_nooverride=1` URL, payment proceeds, and return lands on the thank-you page.
5. Optional: restore a valid Purchase Summary page and confirm a normal absolute custom thank-you URL is left unchanged.

If you don't have Elementor Pro plugin you can just add following snippet to simulate the behaviour:
```php
add_filter(
    'woocommerce_get_endpoint_url',
    function ( $url, $endpoint, $value ) {
		$order_received_endpoint = get_option( 'woocommerce_checkout_order_received_endpoint', 'order-received' );

		if ( $order_received_endpoint === $endpoint ) {
			$order = wc_get_order( $value );

			if ( $order ) {
                $purchase_summary_page_id = 0;
                $url = trailingslashit( trailingslashit( trailingslashit( get_permalink( $purchase_summary_page_id ) ) . $order_received_endpoint ) . $order->get_id() );
			}
		}
		return $url;
	},
    10,
    3
);
```

### Changelog entry
> Fix - Rebuild an absolute checkout thank-you URL when a third-party plugin makes the Payfast return URL relative.
