### PR TITLE
Update E2E subscription setup for WooCommerce Subscriptions 9.0

### DIFF
--- a/tests/e2e/bin/initialize.sh
+++ b/tests/e2e/bin/initialize.sh
@@ -2,6 +2,35 @@
 
 echo "Initializing WooCommerce Gateway Payfast E2E"
 
+# Create a subscribe-only product using the WooCommerce Subscriptions 9.0 purchase-options
+# model (a simple product carrying a single subscription plan in `_wcsatt_schemes`), rather
+# than the legacy `subscription` product type.
+# Args: slug, name, regular price, billing period (day|week|month|year).
+create_subscription_product() {
+	local slug="$1" name="$2" price="$3" period="$4"
+	local scheme_key="1_${period}"
+	local product_id schemes_json
+
+	# Skip if a product with this slug already exists (idempotent re-runs).
+	if wp-env run tests-cli wp wc product list --field=slug --user=1 | grep -qx "${slug}"; then
+		return
+	fi
+
+	wp-env run tests-cli wp wc product create -- \
+		--name="${name}" --slug="${slug}" --user=1 --regular_price="${price}" --virtual=true
+
+	# Resolve the new product's ID by slug so the plan meta can be attached to it.
+	product_id=$(wp-env run tests-cli wp post list --post_type=product --name="${slug}" --format=ids | grep -oE '[0-9]+' | tail -n1)
+
+	# `_wcsatt_schemes` holds a nested array; store it via --format=json so WP-CLI serializes it.
+	# Pricing method "override" sets the plan's own recurring price to the product-level price.
+	schemes_json=$(printf '{"%s":{"id":"%s","key":"%s","subscription_period":"%s","subscription_period_interval":1,"subscription_length":0,"subscription_trial_period":"day","subscription_trial_length":0,"subscription_pricing_method":"override","subscription_regular_price":"%s","subscription_sale_price":"","subscription_discount":""}}' "${scheme_key}" "${scheme_key}" "${scheme_key}" "${period}" "${price}")
+
+	wp-env run tests-cli wp post meta update "${product_id}" _wcsatt_schemes "${schemes_json}" --format=json
+	wp-env run tests-cli wp post meta update "${product_id}" _wcsatt_force_subscription "yes"
+	wp-env run tests-cli wp post meta update "${product_id}" _wcsatt_default_status "subscription"
+}
+
 # Enable pretty permalinks.
 wp-env run tests-wordpress chmod -c ugo+w /var/www/html
 wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
@@ -18,16 +47,16 @@ wp-env run tests-cli wp option update woocommerce_currency "USD"
 wp-env run tests-cli wp option update woocommerce_default_country "US:CA"
 wp-env run tests-cli wp option update woocommerce_allow_tracking "no"
 wp-env run tests-cli wp option update woocommerce_coming_soon "no"
-wp-env run tests-cli wp option update woocommerce_subscriptions_enable_simple_subscription "yes"
-wp-env run tests-cli wp option update woocommerce_subscriptions_enable_variable_subscription "yes"
 
 wp-env run tests-cli wp user create customer customer@euvatnumbertestsuite.com --user_pass=password --role=customer
 
 wp-env run tests-cli wp wc tax create -- --country="*" --state="*" --postcode="*" --city="*" --rate=20 --name="General Tax" --user=1
-wp-env run tests-cli wp wc product create -- --name="Simple Product" --slug="simple-product" --user=1 --regular_price=10 --virtual=true
-wp-env run tests-cli wp wc product create -- --name="Simple Subscription Product" --slug="simple-subscription-product" --user=1 --regular_price=10 --type=subscription --virtual=true --meta_data='[{"key":"_subscription_price","value":"10"},{"key":"_subscription_period","value":"month"},{"key":"_subscription_period_interval","value":"1"}]'
-wp-env run tests-cli wp wc product create -- --name="Second Subscription Product" --slug="second-subscription-product" --user=1 --regular_price=15 --type=subscription --virtual=true --meta_data='[{"key":"_subscription_price","value":"15"},{"key":"_subscription_period","value":"month"},{"key":"_subscription_period_interval","value":"1"}]'
-wp-env run tests-cli wp wc product create -- --name="Yearly Subscription Product" --slug="yearly-subscription-product" --user=1 --regular_price=50 --type=subscription --virtual=true --meta_data='[{"key":"_subscription_price","value":"50"},{"key":"_subscription_period","value":"year"},{"key":"_subscription_period_interval","value":"1"}]'
+if ! wp-env run tests-cli wp wc product list --field=slug --user=1 | grep -qx "simple-product"; then
+	wp-env run tests-cli wp wc product create -- --name="Simple Product" --slug="simple-product" --user=1 --regular_price=10 --virtual=true
+fi
+create_subscription_product "simple-subscription-product" "Simple Subscription Product" "10" "month"
+create_subscription_product "second-subscription-product" "Second Subscription Product" "15" "month"
+create_subscription_product "yearly-subscription-product" "Yearly Subscription Product" "50" "year"
 
 # Add Shortcode checkout page.
 wp-env run tests-cli wp post create --post_title='Shortcode Checkout' --post_type=page --post_status=publish --post_author=1 --post_content='<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->'

--- a/tests/e2e/bin/initialize.sh
+++ b/tests/e2e/bin/initialize.sh
@@ -33,7 +33,6 @@ create_subscription_product() {
 
 	wp-env run tests-cli wp post meta update "${product_id}" _wcsatt_schemes "${schemes_json}" --format=json
 	wp-env run tests-cli wp post meta update "${product_id}" _wcsatt_force_subscription "yes"
-	wp-env run tests-cli wp post meta update "${product_id}" _wcsatt_default_status "subscription"
 }
 
 # Enable pretty permalinks.

--- a/tests/e2e/bin/initialize.sh
+++ b/tests/e2e/bin/initialize.sh
@@ -22,6 +22,11 @@ create_subscription_product() {
 	# Resolve the new product's ID by slug so the plan meta can be attached to it.
 	product_id=$(wp-env run tests-cli wp post list --post_type=product --name="${slug}" --format=ids | grep -oE '[0-9]+' | tail -n1)
 
+	if [[ -z "${product_id}" ]]; then
+		echo "Failed to resolve product ID for slug=${slug}" >&2
+		exit 1
+	fi
+
 	# `_wcsatt_schemes` holds a nested array; store it via --format=json so WP-CLI serializes it.
 	# Pricing method "override" sets the plan's own recurring price to the product-level price.
 	schemes_json=$(printf '{"%s":{"id":"%s","key":"%s","subscription_period":"%s","subscription_period_interval":1,"subscription_length":0,"subscription_trial_period":"day","subscription_trial_length":0,"subscription_pricing_method":"override","subscription_regular_price":"%s","subscription_sale_price":"","subscription_discount":""}}' "${scheme_key}" "${scheme_key}" "${scheme_key}" "${period}" "${price}")

--- a/tests/e2e/bin/initialize.sh
+++ b/tests/e2e/bin/initialize.sh
@@ -53,9 +53,15 @@ wp-env run tests-cli wp option update woocommerce_default_country "US:CA"
 wp-env run tests-cli wp option update woocommerce_allow_tracking "no"
 wp-env run tests-cli wp option update woocommerce_coming_soon "no"
 
-wp-env run tests-cli wp user create customer customer@euvatnumbertestsuite.com --user_pass=password --role=customer
+# Add customer user if it doesn't exist.
+if ! wp-env run tests-cli wp user get customer --field=ID &>/dev/null; then
+    wp-env run tests-cli wp user create customer customer@payfasttestsuite.com --user_pass=password --role=customer
+fi
 
-wp-env run tests-cli wp wc tax create -- --country="*" --state="*" --postcode="*" --city="*" --rate=20 --name="General Tax" --user=1
+if ! wp-env run tests-cli wp wc tax list --field=name --user=1 | grep -q "General Tax"; then
+    wp-env run tests-cli wp wc tax create -- --country="*" --state="*" --postcode="*" --city="*" --rate=20 --name="General Tax" --user=1
+fi
+
 if ! wp-env run tests-cli wp wc product list --field=slug --user=1 | grep -qx "simple-product"; then
 	wp-env run tests-cli wp wc product create -- --name="Simple Product" --slug="simple-product" --user=1 --regular_price=10 --virtual=true
 fi
@@ -64,4 +70,6 @@ create_subscription_product "second-subscription-product" "Second Subscription P
 create_subscription_product "yearly-subscription-product" "Yearly Subscription Product" "50" "year"
 
 # Add Shortcode checkout page.
-wp-env run tests-cli wp post create --post_title='Shortcode Checkout' --post_type=page --post_status=publish --post_author=1 --post_content='<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->'
+if ! wp-env run tests-cli wp post list --post_type=page --field=post_name | grep -q "shortcode-checkout"; then
+	wp-env run tests-cli wp post create --post_title='Shortcode Checkout' --post_type=page --post_status=publish --post_author=1 --post_content='<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->'
+fi


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Updates the E2E environment setup so subscription tests keep working under **WooCommerce Subscriptions 9.0**, which drops the legacy `subscription` product type in favour of the purchase-options model (a simple product carrying a subscription plan). Changes are limited to `tests/e2e/bin/initialize.sh`:

- **Seed subscription products the new way.** Adds a `create_subscription_product()` helper that creates a virtual *simple* product and attaches a single subscription plan via `_wcsatt_schemes` (plus `_wcsatt_force_subscription` / `_wcsatt_default_status`), replacing the old `--type=subscription` product creation for the simple, second, and yearly subscription fixtures.
- **Make product seeding idempotent.** Both the simple product and each subscription product are skipped when a product with the same slug already exists, so re-running the setup on an existing environment no longer creates duplicates.
- **Remove obsolete options.** Drops the `woocommerce_subscriptions_enable_simple_subscription` and `woocommerce_subscriptions_enable_variable_subscription` option updates, which only applied to the retired subscription product type.

No production plugin code is touched — this affects the local/CI E2E environment only. The consuming specs (`subscription-payment.test.js`, `multiple-subscriptions-payment.test.js`) are unchanged and continue to reference the same product slugs.

Closes https://linear.app/a8c/issue/PAYFAST-119/update-subscription-e2e-tests-for-woocommerce-subscriptions-90

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Ensure `tests/e2e/config/.env` has valid Payfast **sandbox** credentials (`PAYFAST_MERCHANT_ID`, `PAYFAST_MERCHANT_KEY`, `PAYFAST_PASSPHRASE`).
1. Start a fresh environment: `npm run env:destroy` then `npm run env:start-local` (runs `initialize.sh`).
1. Confirm the three subscription fixtures were seeded as simple products with a subscription plan — e.g. visit `/product/simple-subscription-product/`, `/product/second-subscription-product/`, `/product/yearly-subscription-product/` and confirm each shows a recurring price and adds to cart as a subscription.
1. Run the subscription suite against WooCommerce Subscriptions 9.0: `npm run test:e2e` — all tests should pass. OR make sure the E2E tests GH action is green.
1. Re-run `npm run env:start-local` (or the initialize script) against the existing environment and confirm no duplicate products are created.

### Changelog entry

> Dev - Update the E2E test setup to seed subscription products using the WooCommerce Subscriptions 9.0 purchase-options model.
