### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/backlog-automation-issues.yml
+++ b/.github/workflows/backlog-automation-issues.yml
@@ -10,6 +10,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       # Checkout the private action repository

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ jobs:
     if: "${{ ( github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'needs: e2e testing') ) ||  github.event_name == 'push' }}"
     name: E2E Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       PAYFAST_MERCHANT_ID: ${{secrets.PAYFAST_MERCHANT_ID}}
       PAYFAST_MERCHANT_KEY: ${{secrets.PAYFAST_MERCHANT_KEY}}

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -7,6 +7,7 @@ on:
 jobs:
     generate-zip-file:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/gh-issue-gen.yml
+++ b/.github/workflows/gh-issue-gen.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   create-gh-issue:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LINEAR_TEAM: PAYFAST

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   sync-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     name: Sync repository labels
     steps:
       - uses: woocommerce/woo-std-labels@91ab3bca9daf544f250eafbbc2b66e039cc0c790 # v1.2.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
   web-deploy:
     name: 🎉 Deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - name: 🚚 Get latest code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -6,6 +6,7 @@ jobs:
   php-compatibility:
     name: PHP compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   phpcs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -37,6 +37,7 @@ jobs:
     needs: build
     name: run
     runs-on: ubuntu-latest
+    timeout-minutes: 40
 
     env:
       NO_COLOR: 1

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -10,6 +10,7 @@ jobs:
   typos:
     name: Check for typos
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `backlog-automation-issues.yml` / `add-to-project` | no runs | no runs | 5 |
| `deploy.yml` / `deploy` | 9.25 min * | 10.32 min * | 15 |
| `e2e.yml` / `e2e` | 10.00 min | 13.82 min | 20 |
| `generate-zip.yml` / `generate-zip-file` | 0.86 min * | 0.90 min * | 5 |
| `gh-issue-gen.yml` / `create-gh-issue` | 0.10 min | 0.88 min | 5 |
| `labels.yml` / `sync-labels` | no runs | no runs | 5 |
| `main.yml` / `web-deploy` | no runs | no runs | 15 |
| `php-compat.yml` / `php-compatibility` | 0.97 min | 1.13 min | 5 |
| `phpcs.yml` / `phpcs` | 0.25 min | 0.37 min | 5 |
| `plugin-check.yml` / `test` | 1.83 min | 2.37 min | 5 |
| `qit.yml` / `test` | 14.59 min * | 32.63 min * | 40 |
| `spell-check.yml` / `typos` | 0.12 min | 0.15 min | 5 |

\* No successful run in the last 30 days; measured over the last 365 days.

`qit.yml` / `build` calls `generate-zip.yml` with `uses:`, where `timeout-minutes` is not valid. The 5-minute limit on `generate-zip-file` bounds it.

Part of TESTOPS-272

Closes #454